### PR TITLE
Add `purposeToTag` to align `RedeemerPurpose` enum with `RedeemerTag` values

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "jest.virtualFolders": [
+    { "name": "blaze-query", "rootPath": "packages/blaze-query" },
+    { "name": "blaze-emulator", "rootPath": "packages/blaze-emulator" }
+    // TODO: enable {      "name": "blaze-tx", "rootPath": "packages/blaze-tx"},
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "jest.virtualFolders": [
-    { "name": "blaze-query", "rootPath": "packages/blaze-query" },
-    { "name": "blaze-emulator", "rootPath": "packages/blaze-emulator" }
-    // TODO: enable {      "name": "blaze-tx", "rootPath": "packages/blaze-tx"},
-  ]
-}

--- a/packages/blaze-query/src/types.ts
+++ b/packages/blaze-query/src/types.ts
@@ -1,14 +1,16 @@
-import type {
-  TransactionUnspentOutput,
-  Address,
-  AssetId,
-  TransactionInput,
-  DatumHash,
-  PlutusData,
-  TransactionId,
-  Transaction,
-  ProtocolParameters,
-  Redeemers,
+import {
+  type TransactionUnspentOutput,
+  type Address,
+  type AssetId,
+  type TransactionInput,
+  type DatumHash,
+  type PlutusData,
+  type TransactionId,
+  type Transaction,
+  type ProtocolParameters,
+  type Redeemers,
+  RedeemerPurpose,
+  RedeemerTag,
 } from "@blaze-cardano/core";
 
 /**
@@ -106,3 +108,16 @@ export abstract class Provider {
     additionalUtxos: TransactionUnspentOutput[],
   ): Promise<Redeemers>;
 }
+
+/**
+ * Mapping of RedeemerPurpose to RedeemerTag.
+ * Ensures consistency between purpose strings and tag numbers.
+ */
+export const purposeToTag: { [key: string]: number } = {
+  [RedeemerPurpose.spend]: RedeemerTag.Spend,
+  [RedeemerPurpose.mint]: RedeemerTag.Mint,
+  [RedeemerPurpose.certificate]: RedeemerTag.Cert,
+  [RedeemerPurpose.withdrawal]: RedeemerTag.Reward,
+  [RedeemerPurpose.vote]: RedeemerTag.Voting,
+  [RedeemerPurpose.propose]: RedeemerTag.Proposing,
+};


### PR DESCRIPTION
Added `purposeTag` to ensure consistency between purpose strings and tag numbers as the `RedeemerPurpose` enum's indexes are still inconsistent with the `RedeemerTag` values in @cardano-sdk/core v0.35.0.

``` js
export declare enum RedeemerTag {
    Spend = 0,
    Mint = 1,
    Cert = 2,
    Reward = 3,
    Voting = 4,
    Proposing = 5
}
```

``` js
export declare enum RedeemerPurpose {
    spend = "spend",
    mint = "mint",
    certificate = "certificate",
    withdrawal = "withdrawal",
    propose = "propose",
    vote = "vote"
}
```