### PR TITLE
Add option to pass staking part to HotSingleWallet

### DIFF
--- a/.changeset/fuzzy-parents-heal.md
+++ b/.changeset/fuzzy-parents-heal.md
@@ -1,0 +1,6 @@
+---
+"@blaze-cardano/wallet": patch
+---
+
+Remove private constructor from `HotSingleWallet`
+Add staking key to `HotSingleWallet`

--- a/packages/blaze-wallet/src/hotsingle.ts
+++ b/packages/blaze-wallet/src/hotsingle.ts
@@ -51,18 +51,18 @@ export class HotSingleWallet implements Wallet {
     paymentSigningKey: Ed25519PrivateNormalKeyHex,
     networkId: NetworkId,
     provider: Provider,
-    stakeSigningKey?: Ed25519PrivateNormalKeyHex
+    stakeSigningKey?: Ed25519PrivateNormalKeyHex,
   ) {
     this.networkId = networkId;
     this.paymentSigningKey = paymentSigningKey;
     this.paymentPublicKey = Ed25519PublicKey.fromHex(
-      derivePublicKey(this.paymentSigningKey)
+      derivePublicKey(this.paymentSigningKey),
     );
 
     if (stakeSigningKey) {
       this.stakeSigningKey = stakeSigningKey;
       this.stakePublicKey = Ed25519PublicKey.fromHex(
-        derivePublicKey(this.stakeSigningKey)
+        derivePublicKey(this.stakeSigningKey),
       );
     }
 
@@ -107,7 +107,7 @@ export class HotSingleWallet implements Wallet {
   async getBalance(): Promise<Value> {
     return (await this.getUnspentOutputs()).reduce(
       (x, y) => value.merge(x, y.output().amount()),
-      value.zero()
+      value.zero(),
     );
   }
 
@@ -152,11 +152,11 @@ export class HotSingleWallet implements Wallet {
    */
   async signTransaction(
     tx: Transaction,
-    partialSign: boolean = true
+    partialSign: boolean = true,
   ): Promise<TransactionWitnessSet> {
     if (partialSign == false) {
       throw new Error(
-        "signTx: Hot single wallet only supports partial signing = true"
+        "signTx: Hot single wallet only supports partial signing = true",
       );
     }
 
@@ -164,7 +164,7 @@ export class HotSingleWallet implements Wallet {
     const tws = new TransactionWitnessSet();
     const vkw = new VkeyWitness(
       this.paymentPublicKey.hex(),
-      Ed25519SignatureHex(signature)
+      Ed25519SignatureHex(signature),
     );
     tws.setVkeys(CborSet.fromCore([vkw.toCore()], VkeyWitness.fromCore));
     return tws;
@@ -179,10 +179,10 @@ export class HotSingleWallet implements Wallet {
    */
   async signData(
     _address: Address,
-    _payload: string
+    _payload: string,
   ): Promise<CIP30DataSignature> {
     throw new Error(
-      "signData: Hot single wallet does not yet support data signing"
+      "signData: Hot single wallet does not yet support data signing",
     );
   }
 

--- a/packages/blaze-wallet/src/hotsingle.ts
+++ b/packages/blaze-wallet/src/hotsingle.ts
@@ -43,7 +43,7 @@ export class HotSingleWallet implements Wallet {
    * @param {NetworkId} networkId - The network ID for the wallet.
    * @param {Provider} provider - The provider for the wallet.
    */
-  private constructor(
+  constructor(
     signingKey: Ed25519PrivateNormalKeyHex,
     networkId: NetworkId,
     provider: Provider,


### PR DESCRIPTION
I want to be able to pass both the payment and staking part as private keys in order to make this wallet. It shouldn't have to just be an enterprise address.