### PR TITLE
bugfix: Fix BlockfrostUTxO type error

### DIFF
--- a/.changeset/orange-socks-kiss.md
+++ b/.changeset/orange-socks-kiss.md
@@ -1,0 +1,5 @@
+---
+"@blaze-cardano/query": patch
+---
+
+Fix BlockfrostUTxO type mismatch

--- a/examples/blockfrost/index.js
+++ b/examples/blockfrost/index.js
@@ -70,10 +70,10 @@ for (const utxo of utxos) {
   console.log(utxoRef);
 
   const amountADA = utxo.output().amount().coin();
-  console.log(`Amount of ADA: ${amountADA / 1000000}`);
+  console.log(`Amount of ADA: ${amountADA / 1000000n}`);
 
   const amountBTN = utxo.output().amount().multiasset().get(btnUnit);
-  console.log(`Amount of ${assetName}: ${amountBTN / 1000000}`);
+  console.log(`Amount of ${assetName}: ${amountBTN / 1000000n}`);
 }
 
 // Some NFT on Preview
@@ -98,7 +98,7 @@ const resolvedOutputs = await provider.resolveUnspentOutputs(txIns);
 
 for (const utxo of resolvedOutputs) {
   const amountADA = utxo.output().amount().coin();
-  console.log(`Amount of ADA: ${amountADA / 1000000}`);
+  console.log(`Amount of ADA: ${amountADA / 1000000n}`);
 
   const multiAssetMap = utxo.output().amount().multiasset();
   for (const [asset, amount] of multiAssetMap.entries()) {

--- a/packages/blaze-query/src/blockfrost.ts
+++ b/packages/blaze-query/src/blockfrost.ts
@@ -617,9 +617,9 @@ function buildTransactionUnspentOutput(
     let lovelace = 0n;
     for (const { unit, quantity } of blockfrostUTxO.amount) {
       if (unit === "lovelace") {
-        lovelace = quantity;
+        lovelace = BigInt(quantity);
       } else {
-        tokenMap.set(unit as AssetId, quantity);
+        tokenMap.set(unit as AssetId, BigInt(quantity));
       }
     }
     const txOut = new TransactionOutput(address, new Value(lovelace, tokenMap));
@@ -683,7 +683,7 @@ interface BlockfrostUTxO {
   output_index: number;
   amount: {
     unit: string;
-    quantity: bigint;
+    quantity: string;
   }[];
   block: string;
   data_hash?: string;


### PR DESCRIPTION
Fix type mismatch between Blockfrost API and `BlockfrostUTxO` on amount quantity. API actually returns `string` and it should be cast to `bigint`.