### PR TITLE
fix: add auxilary data to completed tx

### DIFF
--- a/packages/blaze-tx/src/tx.ts
+++ b/packages/blaze-tx/src/tx.ts
@@ -1232,7 +1232,7 @@ export class TxBuilder {
     } while (final_size != draft_size);
     // Return the fully constructed transaction.
     tw.setVkeys(CborSet.fromCore([], VkeyWitness.fromCore));
-    return new Transaction(this.body, tw);
+    return new Transaction(this.body, tw, this.auxiliaryData);
   }
 
   /**


### PR DESCRIPTION
When completing the transaction we are missing the auxilary data.

This results in an error when submitting the tx `MissingTxMetadata`