### PR TITLE
fix: Fix resolveScript on Kupmios

### DIFF
--- a/.changeset/stupid-buttons-arrive.md
+++ b/.changeset/stupid-buttons-arrive.md
@@ -1,0 +1,5 @@
+---
+"@blaze-cardano/query": patch
+---
+
+Fix resolveScript on Kumpios provider

--- a/packages/blaze-query/src/kupmios.ts
+++ b/packages/blaze-query/src/kupmios.ts
@@ -406,11 +406,11 @@ export class Kupmios implements Provider {
       case "native":
         return Script.newNativeScript(NativeScript.fromCbor(result.script));
       case "plutus:v1":
-        return Script.newPlutusV1Script(PlutusV1Script.fromCbor(result.script));
+        return Script.newPlutusV1Script(new PlutusV1Script(result.script));
       case "plutus:v2":
-        return Script.newPlutusV2Script(PlutusV2Script.fromCbor(result.script));
+        return Script.newPlutusV2Script(new PlutusV2Script(result.script));
       case "plutus:v3":
-        return Script.newPlutusV3Script(PlutusV3Script.fromCbor(result.script));
+        return Script.newPlutusV3Script(new PlutusV3Script(result.script));
 
       default:
         throw new Error(`Unsupported script language: ${result.language}`);


### PR DESCRIPTION
Attempt at fixing `resolveScript` on Kupmios as reported by:

https://discord.com/channels/946071061567529010/1019685247870308362/1266074710756692051

I used the recently added `getScriptRef` to the Blockfrost provider as a reference and tried to make the following result be the same for both providers:


```typescript
// preview testnet
const provider = new Kupmios(kupoUrl, ogmiosUrl);

const txIns = [
  new TransactionInput(
    "74baf638a18a6ab54798cac310112af61cb1f1d6eacb8c893a10b6877cf71a8d",
    1,
  ),
  new TransactionInput(
    "036ed48c89169a9c4e475e08a6d22ea1e09ba8a6a6cfbabfa4f1deefd269652c",
    0,
  ),
];

const resolvedOutputs = await provider.resolveUnspentOutputs(txIns);

for (const result of resolvedOutputs) {
  if (result.output().scriptRef()) console.log(result.output().scriptRef().hash());
}
```