### PR TITLE
chore: fix blockfrost API request

### DIFF
--- a/packages/blaze-query/src/blockfrost.ts
+++ b/packages/blaze-query/src/blockfrost.ts
@@ -463,7 +463,6 @@ export class Blockfrost implements Provider {
       method: "POST",
       headers: {
         "Content-Type": "application/cbor",
-        Accept: "text/plain",
         ...this.headers(),
       },
       body: fromHex(tx.toCbor()),
@@ -476,7 +475,7 @@ export class Blockfrost implements Provider {
       );
     }
 
-    const txId = await response.text();
+    const txId = (await response.json()) as string;
     return TransactionId(txId);
   }
 

--- a/packages/blaze-tx/src/tx.ts
+++ b/packages/blaze-tx/src/tx.ts
@@ -943,9 +943,17 @@ export class TxBuilder {
       // Initialize a CBOR writer to encode the script data.
       const writer = new CborWriter();
       // Encode redeemers and datums into CBOR format.
-      writer.writeStartArray(redeemers.length);
-      for (const redeemer of redeemers) {
-        writer.writeEncodedValue(Buffer.from(redeemer.toCbor(), "hex"));
+      if (redeemers.length === 0) {
+        // An empty redeemer set is always an empty map, as of conway
+        writer.writeStartMap(0);
+      } else {
+        // TODO: in the conway era, this will support array, or map
+        // but in the next era, it will only support maps
+        // So, we should switch this to encoding as maps when we switch the witness set to encoding as maps
+        writer.writeStartArray(redeemers.length);
+        for (const redeemer of redeemers) {
+          writer.writeEncodedValue(Buffer.from(redeemer.toCbor(), "hex"));
+        }
       }
       if (datums && datums.length > 0) {
         writer.writeStartArray(datums.length);


### PR DESCRIPTION
This fixes two issues:

- Blockfrost submission was including an incorrect header, preventing finality.
- Script data hash generation was using outdated models for Conway.