### PR TITLE
chore: make script data hash only valid for chang

### DIFF
--- a/.changeset/afraid-ads-happen.md
+++ b/.changeset/afraid-ads-happen.md
@@ -1,0 +1,5 @@
+---
+"@blaze-cardano/tx": minor
+---
+
+This checks the protocol version to determine if the new script data hash requirements are current yet or not.

--- a/packages/blaze-tx/src/tx.ts
+++ b/packages/blaze-tx/src/tx.ts
@@ -955,7 +955,9 @@ export class TxBuilder {
       // Initialize a CBOR writer to encode the script data.
       const writer = new CborWriter();
       // Encode redeemers and datums into CBOR format.
-      if (redeemers.length === 0) {
+      // In the conway era, the format changes
+      const conway = this.params.protocolVersion.major === 9;
+      if (conway && redeemers.length === 0) {
         // An empty redeemer set is always an empty map, as of conway
         writer.writeStartMap(0);
       } else {


### PR DESCRIPTION
This helps blaze cross the era boundary gracefully, in theory.

Credit to @cjkoepke

Supersedes https://github.com/butaneprotocol/blaze-cardano/pull/129