### PR TITLE
Support Providing Specific Collateral

### DIFF
--- a/packages/blaze-tx/src/tx.ts
+++ b/packages/blaze-tx/src/tx.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   TransactionUnspentOutput,
   TransactionWitnessPlutusData,
   Script,


### PR DESCRIPTION
This PR introduces the ability to specify UTxOs to be used as collateral, if applicable.

This is helpful because some wallets allow the end-user to specify a "collateral UTxO(s)". If that is the case, a dApp should do their best to avoid spending that UTxO, as it could cause issues for the user on other dApps. Currently, blaze does not support such behavior; collateral comes from the full set of UTxOs provided to it, any of which may be spent in the transaction.