### PR TITLE
build: update package.json to be consistent

### DIFF
--- a/.changeset/serious-wasps-fix.md
+++ b/.changeset/serious-wasps-fix.md
@@ -1,0 +1,15 @@
+---
+"@blaze-cardano/blueprint": patch
+"@blaze-cardano/emulator": patch
+"@blaze-cardano/tsconfig": patch
+"@blaze-cardano/ogmios": patch
+"@blaze-cardano/wallet": patch
+"@blaze-cardano/query": patch
+"@blaze-cardano/core": patch
+"@blaze-cardano/uplc": patch
+"@blaze-cardano/sdk": patch
+"@blaze-cardano/tx": patch
+"@blaze-cardano/vm": patch
+---
+
+use package.json exports consistently

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,6 +42,8 @@ jobs:
 
       - name: 🎁 Run build
         run: pnpm build
+        env:
+          NODE_ENV: production
 
       - name: 🧪 Run test
         run: pnpm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_ENV: production

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "workspaces": [
-    "sites/*",
-    "packages/*"
+    "packages/*",
+    "sites/*"
   ],
   "scripts": {
     "build": "turbo run build",
@@ -24,5 +24,6 @@
     "turbo": "^1.13.4",
     "typedoc": "^0.25.13",
     "typescript": "^5.5.4"
-  }
+  },
+  "packageManager": "pnpm@9.9.0+sha512.60c18acd138bff695d339be6ad13f7e936eea6745660d4cc4a776d5247c540d0edee1a563695c183a66eb917ef88f2b4feb1fc25f32a7adcadc7aaf3438e99c1"
 }

--- a/packages/blaze-blueprint/package.json
+++ b/packages/blaze-blueprint/package.json
@@ -2,12 +2,16 @@
   "name": "@blaze-cardano/blueprint",
   "version": "0.4.1",
   "description": "CIP-57 implementation and generator",
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
   "types": "./dist/index.d.ts",
   "bin": "./dist/cli.js",
   "files": [
-    "dist/**"
+    "dist"
   ],
   "scripts": {
     "build": "tsup src/index.ts src/cli.ts --format esm,cjs --dts",

--- a/packages/blaze-blueprint/tsconfig.json
+++ b/packages/blaze-blueprint/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "@blaze-cardano/tsconfig/base.json"
+  "extends": "@blaze-cardano/tsconfig/base.json",
+  "exclude": ["dist", ".turbo", "node_modules"]
 }

--- a/packages/blaze-blueprint/tsconfig.json
+++ b/packages/blaze-blueprint/tsconfig.json
@@ -1,5 +1,3 @@
 {
-  "extends": "@blaze-cardano/tsconfig/base.json",
-  "include": ["."],
-  "exclude": ["dist", "build", "node_modules"]
+  "extends": "@blaze-cardano/tsconfig/base.json"
 }

--- a/packages/blaze-core/package.json
+++ b/packages/blaze-core/package.json
@@ -9,6 +9,9 @@
     }
   },
   "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts",
     "dev": "tsup src/index.ts --format esm,cjs --watch --dts",

--- a/packages/blaze-core/tsconfig.json
+++ b/packages/blaze-core/tsconfig.json
@@ -1,5 +1,4 @@
 {
   "extends": "@blaze-cardano/tsconfig/base.json",
-  "include": ["."],
-  "exclude": ["dist", "build", "node_modules"]
+  "exclude": ["dist", ".turbo", "node_modules"]
 }

--- a/packages/blaze-emulator/package.json
+++ b/packages/blaze-emulator/package.json
@@ -9,6 +9,9 @@
     }
   },
   "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts --external rxjs",
     "dev": "tsup src/index.ts --format esm,cjs --watch --dts --external rxjs",

--- a/packages/blaze-emulator/tsconfig.json
+++ b/packages/blaze-emulator/tsconfig.json
@@ -1,5 +1,4 @@
 {
   "extends": "@blaze-cardano/tsconfig/base.json",
-  "include": ["."],
-  "exclude": ["dist", "build", "node_modules"]
+  "exclude": ["dist", ".turbo", "node_modules"]
 }

--- a/packages/blaze-ogmios/package.json
+++ b/packages/blaze-ogmios/package.json
@@ -2,11 +2,15 @@
   "name": "@blaze-cardano/ogmios",
   "version": "0.0.4",
   "description": "Blaze cardano ogmios library",
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
   "types": "./dist/index.d.ts",
   "files": [
-    "dist/**"
+    "dist"
   ],
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts --external rxjs",

--- a/packages/blaze-ogmios/tsconfig.json
+++ b/packages/blaze-ogmios/tsconfig.json
@@ -1,5 +1,4 @@
 {
   "extends": "@blaze-cardano/tsconfig/base.json",
-  "include": ["."],
-  "exclude": ["dist", "build", "node_modules"]
+  "exclude": ["dist", ".turbo", "node_modules"]
 }

--- a/packages/blaze-query/package.json
+++ b/packages/blaze-query/package.json
@@ -2,11 +2,15 @@
   "name": "@blaze-cardano/query",
   "version": "0.2.12",
   "description": "Blaze cardano emulator library",
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
   "types": "./dist/index.d.ts",
   "files": [
-    "dist/**"
+    "dist"
   ],
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts --external rxjs",

--- a/packages/blaze-query/tsconfig.json
+++ b/packages/blaze-query/tsconfig.json
@@ -1,5 +1,4 @@
 {
   "extends": "@blaze-cardano/tsconfig/base.json",
-  "include": ["."],
-  "exclude": ["dist", "build", "node_modules"]
+  "exclude": ["dist", ".turbo", "node_modules"]
 }

--- a/packages/blaze-sdk/package.json
+++ b/packages/blaze-sdk/package.json
@@ -2,11 +2,15 @@
   "name": "@blaze-cardano/sdk",
   "version": "0.1.22",
   "description": "Blaze cardano sdk library",
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
   "types": "./dist/index.d.ts",
   "files": [
-    "dist/**"
+    "dist"
   ],
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts --external rxjs",

--- a/packages/blaze-sdk/tsconfig.json
+++ b/packages/blaze-sdk/tsconfig.json
@@ -1,5 +1,4 @@
 {
   "extends": "@blaze-cardano/tsconfig/base.json",
-  "include": ["."],
-  "exclude": ["dist", "build", "node_modules"]
+  "exclude": ["dist", ".turbo", "node_modules"]
 }

--- a/packages/blaze-tsconfig/base.json
+++ b/packages/blaze-tsconfig/base.json
@@ -26,6 +26,5 @@
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true
-  },
-  "exclude": ["node_modules"]
+  }
 }

--- a/packages/blaze-tx/package.json
+++ b/packages/blaze-tx/package.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json.schemastore.org/package.json",
   "name": "@blaze-cardano/tx",
   "version": "0.5.5",
   "description": "Blaze cardano transaction building library",
@@ -15,7 +14,7 @@
   },
   "types": "./dist/index.d.ts",
   "files": [
-    "dist/**"
+    "dist"
   ],
   "scripts": {
     "build": "tsup src/index.ts src/value.ts --format esm,cjs --dts --external rxjs",

--- a/packages/blaze-tx/tsconfig.json
+++ b/packages/blaze-tx/tsconfig.json
@@ -1,5 +1,4 @@
 {
   "extends": "@blaze-cardano/tsconfig/base.json",
-  "include": ["."],
-  "exclude": ["dist", "build", "node_modules"]
+  "exclude": ["dist", ".turbo", "node_modules"]
 }

--- a/packages/blaze-uplc/package.json
+++ b/packages/blaze-uplc/package.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json.schemastore.org/package.json",
   "name": "@blaze-cardano/uplc",
   "version": "0.1.16",
   "description": "Blaze untyped plutus core library",
@@ -10,6 +9,9 @@
     }
   },
   "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts --external rxjs",
     "dev": "tsup src/index.ts --format esm,cjs --watch --dts --external rxjs",

--- a/packages/blaze-uplc/tsconfig.json
+++ b/packages/blaze-uplc/tsconfig.json
@@ -1,5 +1,4 @@
 {
   "extends": "@blaze-cardano/tsconfig/base.json",
-  "include": ["."],
-  "exclude": ["dist", "build", "node_modules"]
+  "exclude": ["dist", ".turbo", "node_modules"]
 }

--- a/packages/blaze-vm/package.json
+++ b/packages/blaze-vm/package.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json.schemastore.org/package.json",
   "name": "@blaze-cardano/vm",
   "version": "0.0.35",
   "description": "Blaze cardano plutus virtual machine",
@@ -7,15 +6,11 @@
     ".": {
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
-    },
-    "./value": {
-      "import": "./dist/value.mjs",
-      "require": "./dist/value.js"
     }
   },
   "types": "./dist/index.d.ts",
   "files": [
-    "dist/**"
+    "dist"
   ],
   "scripts": {
     "build": "tsup src/index.ts src/value.ts --format esm,cjs --dts --external rxjs",

--- a/packages/blaze-vm/tsconfig.json
+++ b/packages/blaze-vm/tsconfig.json
@@ -1,5 +1,4 @@
 {
   "extends": "@blaze-cardano/tsconfig/base.json",
-  "include": ["."],
-  "exclude": ["dist", "build", "node_modules"]
+  "exclude": ["dist", ".turbo", "node_modules"]
 }

--- a/packages/blaze-wallet/package.json
+++ b/packages/blaze-wallet/package.json
@@ -2,11 +2,15 @@
   "name": "@blaze-cardano/wallet",
   "version": "0.1.41",
   "description": "Blaze cardano wallet library",
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
   "types": "./dist/index.d.ts",
   "files": [
-    "dist/**"
+    "dist"
   ],
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts --external rxjs",

--- a/packages/blaze-wallet/tsconfig.json
+++ b/packages/blaze-wallet/tsconfig.json
@@ -1,5 +1,4 @@
 {
   "extends": "@blaze-cardano/tsconfig/base.json",
-  "include": ["."],
-  "exclude": ["dist", "build", "node_modules"]
+  "exclude": ["dist", ".turbo", "node_modules"]
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
 packages:
-  - "sites/*"
   - "packages/*"
+  - "sites/*"
   - "!**/examples/**"

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "https://turbo.build/schema.v1.json",
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
When using `"type": "module"` in a project using blaze, some dependencies imports are mixed since the default type is CommonJS, which leads to errors like `Error: require() of ES Module ...`.  

Also using `NODE_ENV=production` ensures any dependencies down the line prefer to use their optimized builds (the dependency graph is too big to analyze heh, but this is the defacto)