### PR TITLE
chore(query): update u5c provider to upstream sdk v0.5.0

### DIFF
--- a/packages/blaze-query/package.json
+++ b/packages/blaze-query/package.json
@@ -39,7 +39,7 @@
     "@blaze-cardano/core": "workspace:*",
     "@blaze-cardano/ogmios": "workspace:*",
     "@blaze-cardano/jest-config": "workspace:*",
-    "@utxorpc/sdk": "0.4.0",
-    "@utxorpc/spec": "0.9.0"
+    "@utxorpc/sdk": "0.5.0",
+    "@utxorpc/spec": "0.10.0"
   }
 }

--- a/packages/blaze-query/src/u5c.ts
+++ b/packages/blaze-query/src/u5c.ts
@@ -62,16 +62,16 @@ export class U5C implements Provider {
   }
 
   async getUnspentOutputs(
-    address: Address
+    address: Address,
   ): Promise<TransactionUnspentOutput[]> {
     const utxoSearchResult = await this.queryClient.searchUtxosByAddress(
-      new Uint8Array(Buffer.from(address.toBytes().toString(), "hex"))
+      new Uint8Array(Buffer.from(address.toBytes().toString(), "hex")),
     );
 
     const utxos = utxoSearchResult.map((item) => {
       const input = new TransactionInput(
         TransactionId(Buffer.from(item.txoRef.hash).toString("hex")),
-        BigInt(item.txoRef.index)
+        BigInt(item.txoRef.index),
       );
 
       const output = this._rpcTxOutToCoreTxOut(item.parsedValued!);
@@ -83,10 +83,10 @@ export class U5C implements Provider {
 
   async getUnspentOutputsWithAsset(
     address: Address,
-    unit: AssetId
+    unit: AssetId,
   ): Promise<TransactionUnspentOutput[]> {
     const addressBytes = new Uint8Array(
-      Buffer.from(address.toBytes().toString(), "hex")
+      Buffer.from(address.toBytes().toString(), "hex"),
     );
 
     const unitBytes = new Uint8Array(Buffer.from(unit.toString(), "hex"));
@@ -95,13 +95,13 @@ export class U5C implements Provider {
       await this.queryClient.searchUtxosByAddressWithAsset(
         addressBytes,
         undefined,
-        unitBytes
+        unitBytes,
       );
 
     return utxoSearchResult.map((item) => {
       const input = new TransactionInput(
         TransactionId(Buffer.from(item.txoRef.hash).toString("hex")),
-        BigInt(item.txoRef.index)
+        BigInt(item.txoRef.index),
       );
 
       const output = this._rpcTxOutToCoreTxOut(item.parsedValued!);
@@ -111,12 +111,12 @@ export class U5C implements Provider {
   }
 
   async getUnspentOutputByNFT(
-    unit: AssetId
+    unit: AssetId,
   ): Promise<TransactionUnspentOutput> {
     const unitBytes = new Uint8Array(Buffer.from(unit.toString(), "hex"));
     const utxoSearchResult = await this.queryClient.searchUtxosByAsset(
       undefined,
-      unitBytes
+      unitBytes,
     );
 
     if (utxoSearchResult.length <= 0) {
@@ -130,7 +130,7 @@ export class U5C implements Provider {
 
     const input = new TransactionInput(
       TransactionId(Buffer.from(item.txoRef.hash).toString("hex")),
-      BigInt(item.txoRef.index)
+      BigInt(item.txoRef.index),
     );
 
     const output = this._rpcTxOutToCoreTxOut(item.parsedValued!);
@@ -139,11 +139,11 @@ export class U5C implements Provider {
   }
 
   async resolveUnspentOutputs(
-    txIns: TransactionInput[]
+    txIns: TransactionInput[],
   ): Promise<TransactionUnspentOutput[]> {
     const references = txIns.map((txIn) => {
       const txHashBytes = new Uint8Array(
-        Buffer.from(txIn.transactionId().toString(), "hex")
+        Buffer.from(txIn.transactionId().toString(), "hex"),
       );
       return {
         txHash: txHashBytes,
@@ -156,7 +156,7 @@ export class U5C implements Provider {
       utxoSearchResult?.map((item) => {
         const input = new TransactionInput(
           TransactionId(Buffer.from(item.txoRef.hash).toString("hex")),
-          BigInt(item.txoRef.index)
+          BigInt(item.txoRef.index),
         );
 
         const output = this._rpcTxOutToCoreTxOut(item.parsedValued!);
@@ -173,7 +173,7 @@ export class U5C implements Provider {
 
   awaitTransactionConfirmation(
     _txId: TransactionId,
-    _timeout?: number
+    _timeout?: number,
   ): Promise<boolean> {
     throw new Error("Method not implemented.");
   }
@@ -186,18 +186,18 @@ export class U5C implements Provider {
 
   evaluateTransaction(
     tx: Transaction,
-    additionalUtxos: TransactionUnspentOutput[]
+    additionalUtxos: TransactionUnspentOutput[],
   ): Promise<Redeemers> {
     console.log("evaluateTransaction", tx, additionalUtxos);
     throw new Error("Method not implemented.");
   }
 
   private _rpcTxOutToCoreTxOut(
-    rpcTxOutput: spec.cardano.TxOutput
+    rpcTxOutput: spec.cardano.TxOutput,
   ): TransactionOutput {
     const output = new TransactionOutput(
       Address.fromBytes(HexBlob.fromBytes(rpcTxOutput.address)),
-      this._rpcTxOutToCoreValue(rpcTxOutput)
+      this._rpcTxOutToCoreValue(rpcTxOutput),
     );
 
     if (rpcTxOutput.datum !== undefined) {
@@ -206,12 +206,14 @@ export class U5C implements Provider {
         rpcTxOutput.datum.originalCbor.length > 0
       ) {
         const inlineDatum = Datum.newInlineData(
-          PlutusData.fromCbor(HexBlob.fromBytes(rpcTxOutput.datum.originalCbor))
+          PlutusData.fromCbor(
+            HexBlob.fromBytes(rpcTxOutput.datum.originalCbor),
+          ),
         );
         output.setDatum(inlineDatum);
       } else if (rpcTxOutput.datum?.hash && rpcTxOutput.datum.hash.length > 0) {
         const datumHash = Datum.newDataHash(
-          DatumHash(Buffer.from(rpcTxOutput.datum.hash).toString("hex"))
+          DatumHash(Buffer.from(rpcTxOutput.datum.hash).toString("hex")),
         );
         output.setDatum(datumHash);
       }
@@ -222,16 +224,16 @@ export class U5C implements Provider {
         const cbor = rpcTxOutput.script.script.value;
         output.setScriptRef(
           Script.newPlutusV1Script(
-            PlutusV1Script.fromCbor(HexBlob.fromBytes(cbor))
-          )
+            PlutusV1Script.fromCbor(HexBlob.fromBytes(cbor)),
+          ),
         );
       }
       if (rpcTxOutput.script.script.case === "plutusV2") {
         const cbor = rpcTxOutput.script.script.value;
         output.setScriptRef(
           Script.newPlutusV2Script(
-            PlutusV2Script.fromCbor(HexBlob.fromBytes(cbor))
-          )
+            PlutusV2Script.fromCbor(HexBlob.fromBytes(cbor)),
+          ),
         );
       }
     }
@@ -242,19 +244,19 @@ export class U5C implements Provider {
   private _rpcTxOutToCoreValue(rpcTxOutput: spec.cardano.TxOutput): Value {
     return new Value(
       BigInt(rpcTxOutput.coin),
-      this._rpcMultiAssetOutputToTokenMap(rpcTxOutput.assets)
+      this._rpcMultiAssetOutputToTokenMap(rpcTxOutput.assets),
     );
   }
 
   private _rpcMultiAssetOutputToTokenMap(
-    multiAsset: spec.cardano.Multiasset[]
+    multiAsset: spec.cardano.Multiasset[],
   ): TokenMap {
     const tokenMap: TokenMap = new Map();
     multiAsset.forEach((ma) => {
       ma.assets.forEach((asset) => {
         const assetId = AssetId.fromParts(
           PolicyId(Buffer.from(ma.policyId).toString("hex")),
-          AssetName(Buffer.from(asset.name).toString("hex"))
+          AssetName(Buffer.from(asset.name).toString("hex")),
         );
 
         const quantity = BigInt(asset.outputCoin);
@@ -270,7 +272,7 @@ export class U5C implements Provider {
   }
 
   private _rpcPParamsToCorePParams(
-    rpcPParams: spec.cardano.PParams
+    rpcPParams: spec.cardano.PParams,
   ): ProtocolParameters {
     return {
       coinsPerUtxoByte: Number(rpcPParams.coinsPerUtxoByte),
@@ -278,22 +280,23 @@ export class U5C implements Provider {
         .set(
           PlutusLanguageVersion.V1,
           rpcPParams.costModels?.plutusV1?.values.map((v) =>
-            Number(v.toString())
+            Number(v.toString()),
           ) ??
             hardCodedProtocolParams.costModels.get(PlutusLanguageVersion.V1) ??
-            []
+            [],
         )
         .set(
           PlutusLanguageVersion.V2,
           rpcPParams.costModels?.plutusV2?.values.map((v) =>
-            Number(v.toString())
+            Number(v.toString()),
           ) ??
             hardCodedProtocolParams.costModels.get(PlutusLanguageVersion.V2) ??
-            []
+            [],
         )
         .set(
           PlutusLanguageVersion.V3,
-          hardCodedProtocolParams.costModels.get(PlutusLanguageVersion.V3) ?? []
+          hardCodedProtocolParams.costModels.get(PlutusLanguageVersion.V3) ??
+            [],
         ),
       maxBlockBodySize: Number(rpcPParams.maxBlockBodySize),
       maxBlockHeaderSize: Number(rpcPParams.maxBlockHeaderSize),

--- a/packages/blaze-query/src/u5c.ts
+++ b/packages/blaze-query/src/u5c.ts
@@ -29,7 +29,7 @@ import {
 } from "@blaze-cardano/core";
 import type { Provider } from "./types";
 import { CardanoQueryClient, CardanoSubmitClient } from "@utxorpc/sdk";
-import type * as Cardano from "@utxorpc/spec/lib/utxorpc/v1alpha/cardano/cardano_pb.js";
+import type * as spec from "@utxorpc/spec";
 
 export class U5C implements Provider {
   private queryClient: CardanoQueryClient;
@@ -62,16 +62,16 @@ export class U5C implements Provider {
   }
 
   async getUnspentOutputs(
-    address: Address,
+    address: Address
   ): Promise<TransactionUnspentOutput[]> {
     const utxoSearchResult = await this.queryClient.searchUtxosByAddress(
-      new Uint8Array(Buffer.from(address.toBytes().toString(), "hex")),
+      new Uint8Array(Buffer.from(address.toBytes().toString(), "hex"))
     );
 
     const utxos = utxoSearchResult.map((item) => {
       const input = new TransactionInput(
         TransactionId(Buffer.from(item.txoRef.hash).toString("hex")),
-        BigInt(item.txoRef.index),
+        BigInt(item.txoRef.index)
       );
 
       const output = this._rpcTxOutToCoreTxOut(item.parsedValued!);
@@ -83,10 +83,10 @@ export class U5C implements Provider {
 
   async getUnspentOutputsWithAsset(
     address: Address,
-    unit: AssetId,
+    unit: AssetId
   ): Promise<TransactionUnspentOutput[]> {
     const addressBytes = new Uint8Array(
-      Buffer.from(address.toBytes().toString(), "hex"),
+      Buffer.from(address.toBytes().toString(), "hex")
     );
 
     const unitBytes = new Uint8Array(Buffer.from(unit.toString(), "hex"));
@@ -95,13 +95,13 @@ export class U5C implements Provider {
       await this.queryClient.searchUtxosByAddressWithAsset(
         addressBytes,
         undefined,
-        unitBytes,
+        unitBytes
       );
 
     return utxoSearchResult.map((item) => {
       const input = new TransactionInput(
         TransactionId(Buffer.from(item.txoRef.hash).toString("hex")),
-        BigInt(item.txoRef.index),
+        BigInt(item.txoRef.index)
       );
 
       const output = this._rpcTxOutToCoreTxOut(item.parsedValued!);
@@ -111,12 +111,12 @@ export class U5C implements Provider {
   }
 
   async getUnspentOutputByNFT(
-    unit: AssetId,
+    unit: AssetId
   ): Promise<TransactionUnspentOutput> {
     const unitBytes = new Uint8Array(Buffer.from(unit.toString(), "hex"));
     const utxoSearchResult = await this.queryClient.searchUtxosByAsset(
       undefined,
-      unitBytes,
+      unitBytes
     );
 
     if (utxoSearchResult.length <= 0) {
@@ -130,7 +130,7 @@ export class U5C implements Provider {
 
     const input = new TransactionInput(
       TransactionId(Buffer.from(item.txoRef.hash).toString("hex")),
-      BigInt(item.txoRef.index),
+      BigInt(item.txoRef.index)
     );
 
     const output = this._rpcTxOutToCoreTxOut(item.parsedValued!);
@@ -139,11 +139,11 @@ export class U5C implements Provider {
   }
 
   async resolveUnspentOutputs(
-    txIns: TransactionInput[],
+    txIns: TransactionInput[]
   ): Promise<TransactionUnspentOutput[]> {
     const references = txIns.map((txIn) => {
       const txHashBytes = new Uint8Array(
-        Buffer.from(txIn.transactionId().toString(), "hex"),
+        Buffer.from(txIn.transactionId().toString(), "hex")
       );
       return {
         txHash: txHashBytes,
@@ -156,7 +156,7 @@ export class U5C implements Provider {
       utxoSearchResult?.map((item) => {
         const input = new TransactionInput(
           TransactionId(Buffer.from(item.txoRef.hash).toString("hex")),
-          BigInt(item.txoRef.index),
+          BigInt(item.txoRef.index)
         );
 
         const output = this._rpcTxOutToCoreTxOut(item.parsedValued!);
@@ -173,7 +173,7 @@ export class U5C implements Provider {
 
   awaitTransactionConfirmation(
     _txId: TransactionId,
-    _timeout?: number,
+    _timeout?: number
   ): Promise<boolean> {
     throw new Error("Method not implemented.");
   }
@@ -186,18 +186,18 @@ export class U5C implements Provider {
 
   evaluateTransaction(
     tx: Transaction,
-    additionalUtxos: TransactionUnspentOutput[],
+    additionalUtxos: TransactionUnspentOutput[]
   ): Promise<Redeemers> {
     console.log("evaluateTransaction", tx, additionalUtxos);
     throw new Error("Method not implemented.");
   }
 
   private _rpcTxOutToCoreTxOut(
-    rpcTxOutput: Cardano.TxOutput,
+    rpcTxOutput: spec.cardano.TxOutput
   ): TransactionOutput {
     const output = new TransactionOutput(
       Address.fromBytes(HexBlob.fromBytes(rpcTxOutput.address)),
-      this._rpcTxOutToCoreValue(rpcTxOutput),
+      this._rpcTxOutToCoreValue(rpcTxOutput)
     );
 
     if (rpcTxOutput.datum !== undefined) {
@@ -206,14 +206,12 @@ export class U5C implements Provider {
         rpcTxOutput.datum.originalCbor.length > 0
       ) {
         const inlineDatum = Datum.newInlineData(
-          PlutusData.fromCbor(
-            HexBlob.fromBytes(rpcTxOutput.datum.originalCbor),
-          ),
+          PlutusData.fromCbor(HexBlob.fromBytes(rpcTxOutput.datum.originalCbor))
         );
         output.setDatum(inlineDatum);
       } else if (rpcTxOutput.datum?.hash && rpcTxOutput.datum.hash.length > 0) {
         const datumHash = Datum.newDataHash(
-          DatumHash(Buffer.from(rpcTxOutput.datum.hash).toString("hex")),
+          DatumHash(Buffer.from(rpcTxOutput.datum.hash).toString("hex"))
         );
         output.setDatum(datumHash);
       }
@@ -224,16 +222,16 @@ export class U5C implements Provider {
         const cbor = rpcTxOutput.script.script.value;
         output.setScriptRef(
           Script.newPlutusV1Script(
-            PlutusV1Script.fromCbor(HexBlob.fromBytes(cbor)),
-          ),
+            PlutusV1Script.fromCbor(HexBlob.fromBytes(cbor))
+          )
         );
       }
       if (rpcTxOutput.script.script.case === "plutusV2") {
         const cbor = rpcTxOutput.script.script.value;
         output.setScriptRef(
           Script.newPlutusV2Script(
-            PlutusV2Script.fromCbor(HexBlob.fromBytes(cbor)),
-          ),
+            PlutusV2Script.fromCbor(HexBlob.fromBytes(cbor))
+          )
         );
       }
     }
@@ -241,22 +239,22 @@ export class U5C implements Provider {
     return output;
   }
 
-  private _rpcTxOutToCoreValue(rpcTxOutput: Cardano.TxOutput): Value {
+  private _rpcTxOutToCoreValue(rpcTxOutput: spec.cardano.TxOutput): Value {
     return new Value(
       BigInt(rpcTxOutput.coin),
-      this._rpcMultiAssetOutputToTokenMap(rpcTxOutput.assets),
+      this._rpcMultiAssetOutputToTokenMap(rpcTxOutput.assets)
     );
   }
 
   private _rpcMultiAssetOutputToTokenMap(
-    multiAsset: Cardano.Multiasset[],
+    multiAsset: spec.cardano.Multiasset[]
   ): TokenMap {
     const tokenMap: TokenMap = new Map();
     multiAsset.forEach((ma) => {
       ma.assets.forEach((asset) => {
         const assetId = AssetId.fromParts(
           PolicyId(Buffer.from(ma.policyId).toString("hex")),
-          AssetName(Buffer.from(asset.name).toString("hex")),
+          AssetName(Buffer.from(asset.name).toString("hex"))
         );
 
         const quantity = BigInt(asset.outputCoin);
@@ -272,7 +270,7 @@ export class U5C implements Provider {
   }
 
   private _rpcPParamsToCorePParams(
-    rpcPParams: Cardano.PParams,
+    rpcPParams: spec.cardano.PParams
   ): ProtocolParameters {
     return {
       coinsPerUtxoByte: Number(rpcPParams.coinsPerUtxoByte),
@@ -280,23 +278,22 @@ export class U5C implements Provider {
         .set(
           PlutusLanguageVersion.V1,
           rpcPParams.costModels?.plutusV1?.values.map((v) =>
-            Number(v.toString()),
+            Number(v.toString())
           ) ??
             hardCodedProtocolParams.costModels.get(PlutusLanguageVersion.V1) ??
-            [],
+            []
         )
         .set(
           PlutusLanguageVersion.V2,
           rpcPParams.costModels?.plutusV2?.values.map((v) =>
-            Number(v.toString()),
+            Number(v.toString())
           ) ??
             hardCodedProtocolParams.costModels.get(PlutusLanguageVersion.V2) ??
-            [],
+            []
         )
         .set(
           PlutusLanguageVersion.V3,
-          hardCodedProtocolParams.costModels.get(PlutusLanguageVersion.V3) ??
-            [],
+          hardCodedProtocolParams.costModels.get(PlutusLanguageVersion.V3) ?? []
         ),
       maxBlockBodySize: Number(rpcPParams.maxBlockBodySize),
       maxBlockHeaderSize: Number(rpcPParams.maxBlockHeaderSize),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 8.57.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4))
+        version: 29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4))
       prettier:
         specifier: ^3.3.3
         version: 3.3.3
@@ -73,13 +73,13 @@ importers:
         version: 8.57.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4))
+        version: 29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4))
       ts-jest:
         specifier: ^29.2.3
-        version: 29.2.5(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(esbuild@0.23.1)(jest@29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4)))(typescript@5.5.4)
+        version: 29.2.5(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(jest@29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4)))(typescript@5.5.4)
       tsup:
         specifier: ^8.2.3
-        version: 8.2.4(@swc/core@1.7.23)(postcss@8.4.31)(tsx@4.18.0)(typescript@5.5.4)
+        version: 8.2.4(@swc/core@1.7.23(@swc/helpers@0.5.2))(postcss@8.4.31)(tsx@4.18.0)(typescript@5.5.4)
       tsx:
         specifier: ^4.16.2
         version: 4.18.0
@@ -128,7 +128,7 @@ importers:
         version: 5.31.6
       tsup:
         specifier: ^8.2.3
-        version: 8.2.4(@swc/core@1.7.23)(postcss@8.4.31)(tsx@4.18.0)(typescript@5.5.4)
+        version: 8.2.4(@swc/core@1.7.23(@swc/helpers@0.5.2))(postcss@8.4.31)(tsx@4.18.0)(typescript@5.5.4)
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
@@ -171,16 +171,16 @@ importers:
         version: 8.57.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4))
+        version: 29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4))
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(esbuild@0.23.1)(jest@29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4)))(typescript@5.5.4)
+        version: 29.2.5(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(jest@29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4)))(typescript@5.5.4)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4)
+        version: 10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4)
       tsup:
         specifier: ^8.0.2
-        version: 8.2.4(@swc/core@1.7.23)(postcss@8.4.31)(tsx@4.18.0)(typescript@5.5.4)
+        version: 8.2.4(@swc/core@1.7.23(@swc/helpers@0.5.2))(postcss@8.4.31)(tsx@4.18.0)(typescript@5.5.4)
       typescript:
         specifier: ^5.3.3
         version: 5.5.4
@@ -204,7 +204,7 @@ importers:
     devDependencies:
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(jest@29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.5.4)))(typescript@5.5.4)
+        version: 29.2.5(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(jest@29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4)))(typescript@5.5.4)
 
   packages/blaze-ogmios:
     dependencies:
@@ -226,10 +226,10 @@ importers:
         version: 8.57.0
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4)
+        version: 10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4)
       tsup:
         specifier: ^8.0.2
-        version: 8.2.4(@swc/core@1.7.23)(postcss@8.4.31)(tsx@4.18.0)(typescript@5.5.4)
+        version: 8.2.4(@swc/core@1.7.23(@swc/helpers@0.5.2))(postcss@8.4.31)(tsx@4.18.0)(typescript@5.5.4)
       typescript:
         specifier: ^5.3.3
         version: 5.5.4
@@ -249,11 +249,11 @@ importers:
         specifier: ^6.4.0
         version: 6.6.0
       '@utxorpc/sdk':
-        specifier: 0.4.0
-        version: 0.4.0(@bufbuild/protobuf@1.10.0)
+        specifier: 0.5.0
+        version: 0.5.0(@bufbuild/protobuf@1.10.0)
       '@utxorpc/spec':
-        specifier: 0.9.0
-        version: 0.9.0
+        specifier: 0.10.0
+        version: 0.10.0
       ws:
         specifier: ^8.17.1
         version: 8.18.0
@@ -275,16 +275,16 @@ importers:
         version: 8.57.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4))
+        version: 29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4))
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(esbuild@0.23.1)(jest@29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4)))(typescript@5.5.4)
+        version: 29.2.5(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(jest@29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4)))(typescript@5.5.4)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4)
+        version: 10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4)
       tsup:
         specifier: ^8.0.2
-        version: 8.2.4(@swc/core@1.7.23)(postcss@8.4.31)(tsx@4.18.0)(typescript@5.5.4)
+        version: 8.2.4(@swc/core@1.7.23(@swc/helpers@0.5.2))(postcss@8.4.31)(tsx@4.18.0)(typescript@5.5.4)
       typescript:
         specifier: ^5.3.3
         version: 5.5.4
@@ -318,7 +318,7 @@ importers:
         version: 8.57.0
       tsup:
         specifier: ^8.0.2
-        version: 8.2.4(@swc/core@1.7.23)(postcss@8.4.31)(tsx@4.18.0)(typescript@5.5.4)
+        version: 8.2.4(@swc/core@1.7.23(@swc/helpers@0.5.2))(postcss@8.4.31)(tsx@4.18.0)(typescript@5.5.4)
       typescript:
         specifier: ^5.3.3
         version: 5.5.4
@@ -351,16 +351,16 @@ importers:
         version: 8.57.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4))
+        version: 29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4))
       ts-jest:
         specifier: ^29.1.1
-        version: 29.2.5(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(esbuild@0.23.1)(jest@29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4)))(typescript@5.5.4)
+        version: 29.2.5(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(jest@29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4)))(typescript@5.5.4)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4)
+        version: 10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4)
       tsup:
         specifier: ^8.0.2
-        version: 8.2.4(@swc/core@1.7.23)(postcss@8.4.31)(tsx@4.18.0)(typescript@5.5.4)
+        version: 8.2.4(@swc/core@1.7.23(@swc/helpers@0.5.2))(postcss@8.4.31)(tsx@4.18.0)(typescript@5.5.4)
       typescript:
         specifier: ^5.3.3
         version: 5.5.4
@@ -397,13 +397,13 @@ importers:
         version: 8.57.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4))
+        version: 29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4))
       ts-jest:
         specifier: ^29.2.3
-        version: 29.2.5(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(esbuild@0.23.1)(jest@29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4)))(typescript@5.5.4)
+        version: 29.2.5(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(jest@29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4)))(typescript@5.5.4)
       tsup:
         specifier: ^8.2.3
-        version: 8.2.4(@swc/core@1.7.23)(postcss@8.4.31)(tsx@4.18.0)(typescript@5.5.4)
+        version: 8.2.4(@swc/core@1.7.23(@swc/helpers@0.5.2))(postcss@8.4.31)(tsx@4.18.0)(typescript@5.5.4)
       typescript:
         specifier: ^5.5.4
         version: 5.5.4
@@ -434,7 +434,7 @@ importers:
         version: 8.57.0
       tsup:
         specifier: ^8.0.2
-        version: 8.2.4(@swc/core@1.7.23)(postcss@8.4.31)(tsx@4.18.0)(typescript@5.5.4)
+        version: 8.2.4(@swc/core@1.7.23(@swc/helpers@0.5.2))(postcss@8.4.31)(tsx@4.18.0)(typescript@5.5.4)
       typescript:
         specifier: ^5.3.3
         version: 5.5.4
@@ -462,7 +462,7 @@ importers:
         version: 8.57.0
       tsup:
         specifier: ^8.0.2
-        version: 8.2.4(@swc/core@1.7.23)(postcss@8.4.31)(tsx@4.18.0)(typescript@5.5.4)
+        version: 8.2.4(@swc/core@1.7.23(@swc/helpers@0.5.2))(postcss@8.4.31)(tsx@4.18.0)(typescript@5.5.4)
       typescript:
         specifier: ^5.3.3
         version: 5.5.4
@@ -1722,12 +1722,12 @@ packages:
   '@ungap/structured-clone@1.2.0':
     resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
 
-  '@utxorpc/sdk@0.4.0':
-    resolution: {integrity: sha512-wYMqXtaoaT2q3ZufZMi/K5SZOxB2S4OCSq2Wti//odk46OG/5gzrKCAB8gC1D9FAu/NNdt0SzgZ0uFShNLtiMA==}
+  '@utxorpc/sdk@0.5.0':
+    resolution: {integrity: sha512-fBGkGwEKNWqsGtTexLXPnUvsa3/tWyQG9yzRCkqdEsTMSLgnfkKb0iLFq71lh7D3o1cpppRRqg9qVafyEY4d5Q==}
 
-  '@utxorpc/spec@0.9.0':
-    resolution: {integrity: sha512-MSAbFrYr2dXkuHSDWYMkItYv5anuzeGd50t2+XjBoaI/eCNhviflLpl1i90XB00a1LOuHyS8o2Z+EBgB5i/h/A==}
-    engines: {node: '>=16.0.0'}
+  '@utxorpc/spec@0.10.0':
+    resolution: {integrity: sha512-gem0QVOxCyDMpy5x2v/6lJ8PcLgYehnpT/oHm9tM/uQxOnahd5lSERbnCL1ay+G1YlniEwScRls/a90OBhZMUQ==}
+    engines: {node: '>=20.0.0'}
 
   '@zxing/text-encoding@0.9.0':
     resolution: {integrity: sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==}
@@ -5642,7 +5642,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -5656,7 +5656,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4))
+      jest-config: 29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -6076,7 +6076,7 @@ snapshots:
   '@swc/core-win32-x64-msvc@1.7.23':
     optional: true
 
-  '@swc/core@1.7.23':
+  '@swc/core@1.7.23(@swc/helpers@0.5.2)':
     dependencies:
       '@swc/counter': 0.1.3
       '@swc/types': 0.1.12
@@ -6091,6 +6091,7 @@ snapshots:
       '@swc/core-win32-arm64-msvc': 1.7.23
       '@swc/core-win32-ia32-msvc': 1.7.23
       '@swc/core-win32-x64-msvc': 1.7.23
+      '@swc/helpers': 0.5.2
     optional: true
 
   '@swc/counter@0.1.3':
@@ -6363,16 +6364,16 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@utxorpc/sdk@0.4.0(@bufbuild/protobuf@1.10.0)':
+  '@utxorpc/sdk@0.5.0(@bufbuild/protobuf@1.10.0)':
     dependencies:
       '@connectrpc/connect': 1.4.0(@bufbuild/protobuf@1.10.0)
       '@connectrpc/connect-node': 1.4.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.4.0(@bufbuild/protobuf@1.10.0))
       '@types/node': 20.14.10
-      '@utxorpc/spec': 0.9.0
+      '@utxorpc/spec': 0.10.0
     transitivePeerDependencies:
       - '@bufbuild/protobuf'
 
-  '@utxorpc/spec@0.9.0':
+  '@utxorpc/spec@0.10.0':
     dependencies:
       '@bufbuild/protobuf': 1.10.0
 
@@ -6792,13 +6793,13 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.11
 
-  create-jest@29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4)):
+  create-jest@29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4))
+      jest-config: 29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -7911,16 +7912,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4)):
+  jest-cli@29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4))
+      create-jest: 29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4))
+      jest-config: 29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -7930,7 +7931,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4)):
+  jest-config@29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4)):
     dependencies:
       '@babel/core': 7.25.2
       '@jest/test-sequencer': 29.7.0
@@ -7956,7 +7957,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.16.1
-      ts-node: 10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4)
+      ts-node: 10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -8176,12 +8177,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4)):
+  jest@29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4))
+      jest-cli: 29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -9665,32 +9666,12 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.2.5(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(esbuild@0.23.1)(jest@29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4)))(typescript@5.5.4):
+  ts-jest@29.2.5(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(jest@29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4)))(typescript@5.5.4):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4))
-      jest-util: 29.7.0
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.6.3
-      typescript: 5.5.4
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.25.2
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.25.2)
-      esbuild: 0.23.1
-
-  ts-jest@29.2.5(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(jest@29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@types/node@20.16.1)(typescript@5.5.4)))(typescript@5.5.4):
-    dependencies:
-      bs-logger: 0.2.6
-      ejs: 3.1.10
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4))
+      jest: 29.7.0(@types/node@20.16.1)(ts-node@10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -9706,7 +9687,7 @@ snapshots:
 
   ts-log@2.2.5: {}
 
-  ts-node@10.9.2(@swc/core@1.7.23)(@types/node@20.16.1)(typescript@5.5.4):
+  ts-node@10.9.2(@swc/core@1.7.23(@swc/helpers@0.5.2))(@types/node@20.16.1)(typescript@5.5.4):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -9724,13 +9705,13 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
-      '@swc/core': 1.7.23
+      '@swc/core': 1.7.23(@swc/helpers@0.5.2)
 
   tslib@2.3.1: {}
 
   tslib@2.7.0: {}
 
-  tsup@8.2.4(@swc/core@1.7.23)(postcss@8.4.31)(tsx@4.18.0)(typescript@5.5.4):
+  tsup@8.2.4(@swc/core@1.7.23(@swc/helpers@0.5.2))(postcss@8.4.31)(tsx@4.18.0)(typescript@5.5.4):
     dependencies:
       bundle-require: 5.0.0(esbuild@0.23.1)
       cac: 6.7.14
@@ -9749,7 +9730,7 @@ snapshots:
       sucrase: 3.35.0
       tree-kill: 1.2.2
     optionalDependencies:
-      '@swc/core': 1.7.23
+      '@swc/core': 1.7.23(@swc/helpers@0.5.2)
       postcss: 8.4.31
       typescript: 5.5.4
     transitivePeerDependencies:


### PR DESCRIPTION
In this PR we update the u5c provider to use the latest upstream packages. These new versions include the following changes:

- Conway-specific structs (new costmodel, new certs, etc)
- The packages now provide both esm and commonjs builds