### PR TITLE
Fix slotConfig inconsistency, update Kupmios example, and bump blaze-ogmios version for changeset release

### DIFF
--- a/examples/kupmios/index.js
+++ b/examples/kupmios/index.js
@@ -4,21 +4,21 @@ import {
   wordlist,
 } from "../../packages/blaze-core/dist/index.js";
 import { Kupmios } from "../../packages/blaze-query/dist/index.js";
-import { Unwrapped } from "../../packages/blaze-ogmios";
+import { Unwrapped } from "../../packages/blaze-ogmios/dist/index.js";
 import { Blaze } from "../../packages/blaze-sdk/dist/index.js";
 import { HotWallet } from "../../packages/blaze-wallet/dist/index.js";
 
 // Tested with Kupo v2.8.0
-const kupoUrl = "<YOUR KUPO ENDPOINT>";
+const kupoUrl = "http://localhost:1442";
 
 // Tested with Ogmios v6.3.0
-const ogmiosUrl = "<YOUR OGMIOS ENDPOINT>";
+const ogmiosUrl = "http://localhost:1337";
 const ogmios = await Unwrapped.Ogmios.new(ogmiosUrl);
 
 const provider = new Kupmios(kupoUrl, ogmios);
 
-const mnemonic = "<YOUR MNEMONIC THAT CONTAINS FUND TO SEND>";
-
+const mnemonic =
+  "test test test test test test test test test test test test test test test test test test test test test test test sauce";
 const entropy = mnemonicToEntropy(mnemonic, wordlist);
 const masterkey = Bip32PrivateKey.fromBip39Entropy(Buffer.from(entropy), "");
 

--- a/packages/blaze-emulator/src/emulator.ts
+++ b/packages/blaze-emulator/src/emulator.ts
@@ -137,7 +137,18 @@ export class Emulator {
     }
     this.clock = new LedgerTimer(slotConfig);
     this.params = params;
-    this.evaluator = evaluator ?? makeUplcEvaluator(params, 1, 1, slotConfig);
+    this.evaluator =
+      evaluator ??
+      makeUplcEvaluator(
+        params,
+        1,
+        1,
+        slotConfig ?? {
+          zeroSlot: this.clock.slot,
+          zeroTime: this.clock.time,
+          slotLength: this.clock.slotLength,
+        },
+      );
     this.addUtxo = this.addUtxo.bind(this);
     this.removeUtxo = this.removeUtxo.bind(this);
   }

--- a/packages/blaze-ogmios/package.json
+++ b/packages/blaze-ogmios/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blaze-cardano/ogmios",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Blaze cardano ogmios library",
   "exports": {
     ".": {
@@ -30,7 +30,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@cardano-ogmios/schema": "^6.4.0",
+    "@cardano-ogmios/schema": "^6.6.1",
     "isomorphic-ws": "^5.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,7 +209,7 @@ importers:
   packages/blaze-ogmios:
     dependencies:
       '@cardano-ogmios/schema':
-        specifier: ^6.4.0
+        specifier: ^6.6.1
         version: 6.6.1
       isomorphic-ws:
         specifier: ^5.0.0


### PR DESCRIPTION
This PR includes the following changes:
1. Fix slotConfig inconsistency:
This resolves the mismatch between `LedgerTimer'`s default configuration and `makeUplcEvaluator'`s default (mainnet) configuration.
2. Update Kupmios example:
Fixed and updated the Kupmios example so that it functions correctly again.
3. Bump `@blaze-cardano/ogmios` version:
Bumped the version of `@blaze-cardano/ogmios` for a previously missed changeset release.

