### PR TITLE
Fix correct collateral percentage calculation and add initial support for PlutusV3 script

### DIFF
--- a/packages/blaze-core/src/params.ts
+++ b/packages/blaze-core/src/params.ts
@@ -75,7 +75,7 @@ export const hardCodedProtocolParams: ProtocolParameters = {
   minPoolCost: 170000000, // The minimum pool cost.
   protocolVersion: { major: 9, minor: 0 }, // The protocol version.
   maxValueSize: 5000, // The maximum value size.
-  collateralPercentage: 150 / 100, // The collateral percentage.
+  collateralPercentage: 150, // The collateral percentage.
   maxCollateralInputs: 3, // The maximum collateral inputs.
   costModels: new Map() // The cost models.
     .set(

--- a/packages/blaze-emulator/src/emulator.ts
+++ b/packages/blaze-emulator/src/emulator.ts
@@ -504,7 +504,7 @@ export class Emulator {
 
     // Minimum collateral amount included
     const minCollateral = BigInt(
-      Math.ceil(this.params.collateralPercentage * Number(body.fee())),
+      Math.ceil((this.params.collateralPercentage * Number(body.fee())) / 100),
     );
 
     // If any scripts have been invoked, minimum collateral must be included

--- a/packages/blaze-query/src/blockfrost.ts
+++ b/packages/blaze-query/src/blockfrost.ts
@@ -112,7 +112,7 @@ export class Blockfrost implements Provider {
         minor: response.protocol_minor_ver,
       },
       maxValueSize: response.max_val_size,
-      collateralPercentage: response.collateral_percent / 100,
+      collateralPercentage: response.collateral_percent,
       maxCollateralInputs: response.max_collateral_inputs,
       costModels: costModels,
       prices: {

--- a/packages/blaze-query/src/maestro.ts
+++ b/packages/blaze-query/src/maestro.ts
@@ -94,7 +94,7 @@ export class Maestro implements Provider {
             minPoolCost: params.min_stake_pool_cost.ada.lovelace,
             protocolVersion: params.version,
             maxValueSize: params.max_value_size.bytes,
-            collateralPercentage: params.collateral_percentage / 100,
+            collateralPercentage: params.collateral_percentage,
             maxCollateralInputs: params.max_collateral_inputs,
             costModels: costModels,
             prices: {

--- a/packages/blaze-tx/src/tx.ts
+++ b/packages/blaze-tx/src/tx.ts
@@ -1394,8 +1394,9 @@ export class TxBuilder {
     // Calculate the total collateral based on the transaction fee and collateral percentage.
     const totalCollateral = BigInt(
       Math.ceil(
-        this.params.collateralPercentage *
-          Number(bigintMax(this.fee, this.minimumFee) + this.feePadding),
+        (this.params.collateralPercentage *
+          Number(bigintMax(this.fee, this.minimumFee) + this.feePadding)) /
+          100,
       ),
     );
     // Calculate the collateral value by summing up the amounts from collateral inputs.

--- a/packages/blaze-uplc/src/utils.ts
+++ b/packages/blaze-uplc/src/utils.ts
@@ -7,6 +7,7 @@ import {
   CborReader,
   CborWriter,
   CborReaderState,
+  PlutusV3Script,
 } from "@blaze-cardano/core";
 import { HexBlob } from "@blaze-cardano/core";
 import { UPLCDecoder } from "./decoder";
@@ -123,7 +124,7 @@ export function cborToScript(cbor: string, type: ScriptType): Script {
     } else if (type === "PlutusV2") {
       return Script.newPlutusV2Script(new PlutusV2Script(cborHex));
     } else {
-      throw new Error("Unsupported script type");
+      return Script.newPlutusV3Script(new PlutusV3Script(cborHex));
     }
   }
 }


### PR DESCRIPTION
This pull request corrects the collateral percentage calculation. 

The collateral percentage was previously defined as a rational number (e.g. 150/100), but it should be defined as a natural number (e.g. 150) to be consistent with the genesis configs.  
This change ensures consistency in the collateral percentage, correct calculation, and avoids the issue of collateral being 100 times larger than expected in Kupmios povider.

Additionally, this pull request adds initial support for PlutusV3 scripts in the blaze-uplc package. 
This initial support may require additional commits to fully implement the feature.
