### PR TITLE
fix: consider preliminaryFee on fee calculation

### DIFF
--- a/.changeset/flat-plants-roll.md
+++ b/.changeset/flat-plants-roll.md
@@ -1,0 +1,5 @@
+---
+"@blaze-cardano/tx": patch
+---
+
+Fix fee calculation before evaluation

--- a/packages/blaze-tx/src/tx.ts
+++ b/packages/blaze-tx/src/tx.ts
@@ -1558,7 +1558,10 @@ export class TxBuilder {
     this.calculateFees(draft_tx);
     excessValue = value.merge(
       excessValue,
-      new Value(-(bigintMax(this.fee, this.minimumFee) + this.feePadding)),
+      new Value(
+        -(bigintMax(this.fee, this.minimumFee) + this.feePadding) +
+          BigInt(preliminaryFee),
+      ),
     );
     this.balanceChange(excessValue);
     let evaluationFee: bigint = 0n;


### PR DESCRIPTION
When evaluating there is a diff between the outputChange and the fee set in the tx. This is due to substracting the preliminaryFee both the first time we calculate the excessValue and when merging in the modifiied line