### PR TITLE
chore: submit transactions through the wallet by default

### DIFF
--- a/.changeset/olive-comics-teach.md
+++ b/.changeset/olive-comics-teach.md
@@ -1,0 +1,6 @@
+---
+"@blaze-cardano/sdk": minor
+"@blaze-cardano/tx": minor
+---
+
+Submit built transactions through the wallet by default, while allowing a provider option.

--- a/packages/blaze-sdk/src/blaze.ts
+++ b/packages/blaze-sdk/src/blaze.ts
@@ -98,7 +98,12 @@ export class Blaze<ProviderType extends Provider, WalletType extends Wallet> {
    * @description This method sends the provided transaction to the blockchain network
    * using the configured wallet, or the configured provider if set.
    */
-  async submitTransaction(tx: Transaction, useProvider?: boolean): Promise<TransactionId> {
-    return useProvider ? this.provider.postTransactionToChain(tx) : this.wallet.postTransaction(tx);
+  async submitTransaction(
+    tx: Transaction,
+    useProvider?: boolean,
+  ): Promise<TransactionId> {
+    return useProvider
+      ? this.provider.postTransactionToChain(tx)
+      : this.wallet.postTransaction(tx);
   }
 }

--- a/packages/blaze-sdk/src/blaze.ts
+++ b/packages/blaze-sdk/src/blaze.ts
@@ -96,9 +96,9 @@ export class Blaze<ProviderType extends Provider, WalletType extends Wallet> {
    * @returns {Promise<TransactionId>} - The transaction ID.
    * @throws {Error} If the transaction submission fails.
    * @description This method sends the provided transaction to the blockchain network
-   * using the configured provider.
+   * using the configured wallet, or the configured provider if set.
    */
-  async submitTransaction(tx: Transaction): Promise<TransactionId> {
-    return this.provider.postTransactionToChain(tx);
+  async submitTransaction(tx: Transaction, useProvider?: boolean): Promise<TransactionId> {
+    return useProvider ? this.provider.postTransactionToChain(tx) : this.wallet.postTransaction(tx);
   }
 }


### PR DESCRIPTION
This PR submit transactions through the wallet by default, while retaining the ability to shortcut to the provider.