### PR TITLE
Adjust Maestro::getUnspentOutputByNFT flow to prevent race condition.

### DIFF
--- a/.changeset/gentle-tools-own.md
+++ b/.changeset/gentle-tools-own.md
@@ -1,0 +1,5 @@
+---
+"@blaze-cardano/query": patch
+---
+
+Adjust Maestro::getUnspentOutputByNFT flow to prevent race condition.


### PR DESCRIPTION
Race condition checking the utxos array length while a fetch may still be happening asynchronously highlighed below.
```typescript
const utxos: TransactionUnspentOutput[] = [];
for (const maestroUTxO of response.data) {
  //...snip
  fetch(`${this.url}${query2}?with_cbor=true`, {
    headers: this.headers(),
  })
    .then((resp) => resp.json())
    .then((json) => {
        //...snip
        utxos.push(new TransactionUnspentOutput(txIn, txOut));
       //...snip
    });
}
// This check can happen before the async fetch in the for loop above completes
if (utxos.length !== 1)  {
  throw new Error(
    "getUnspentOutputByNFT: Expected 1 UTxO, got " + utxos.length,
  );
}
 ```

I moved the array length check to before the fetch using the initial `response.data` array instead which should have the same behavior.   I then removed the for loop since it is guaranteed after that check to be a single utxo in the array.