### PR TITLE
fix: wrong final_size calculation

### DIFF
--- a/.changeset/mighty-news-try.md
+++ b/.changeset/mighty-news-try.md
@@ -1,0 +1,5 @@
+---
+"@blaze-cardano/tx": patch
+---
+
+Small fee calculation fix

--- a/packages/blaze-tx/src/tx.ts
+++ b/packages/blaze-tx/src/tx.ts
@@ -1620,7 +1620,7 @@ export class TxBuilder {
         "A transaction was built using fee padding. This is useful for working around changes to fee calculation, but ultimately is a bandaid. If you find yourself needing this, please open a ticket at https://github.com/butaneprotocol/blaze-cardano so we can fix the underlying inaccuracy!",
       );
     }
-    let final_size = draft_tx.toCbor().length / 2;
+    let final_size = draft_size;
     do {
       const oldEvaluationFee = evaluationFee;
       this.fee += BigInt(


### PR DESCRIPTION
Fix a small fee calculation issue. Final Size should be initialized to draft_size as after draft_tx is initialize the witness set is updated so the actual size changes but its not accounted in the fee calculation. This could lead to some edge cases where the tx is balanced, size remains the same and the tx_size doesn't change so the fee will be lower than it should