### PR TITLE
Basic Script Deployment Utils

### DIFF
--- a/.changeset/eleven-walls-return.md
+++ b/.changeset/eleven-walls-return.md
@@ -1,0 +1,9 @@
+---
+"@blaze-cardano/emulator": minor
+"@blaze-cardano/query": minor
+"@blaze-cardano/core": minor
+"@blaze-cardano/tx": minor
+"@blaze-cardano/ogmios": patch
+---
+
+feat: Script deployment methods for tx and script-ref resolving provider query

--- a/packages/blaze-core/src/util.ts
+++ b/packages/blaze-core/src/util.ts
@@ -6,7 +6,6 @@ import type {
   PaymentAddress,
   Script,
   NetworkId,
-  Credential,
   Ed25519PrivateExtendedKeyHex,
   Ed25519PrivateNormalKeyHex,
 } from "./types";
@@ -18,6 +17,7 @@ import {
   AddressType,
   Hash32ByteBase16,
   Ed25519SignatureHex,
+  Credential,
 } from "./types";
 import { sha256 } from "@noble/hashes/sha256";
 import * as sha3 from "@noble/hashes/sha3";
@@ -268,6 +268,17 @@ export const addressFromCredentials = (
     networkId: network,
   });
 };
+
+const burnCred = Credential.fromCore({
+  hash: Hash28ByteBase16(
+    // From https://cardano-tools.io/burn-address
+    "bbece14f554b0020fe2715d05801f4680ebd40d11a58f14740b9f2c5",
+  ),
+  type: CredentialType.ScriptHash,
+});
+
+export const getBurnAddress = (network: NetworkId) =>
+  addressFromCredential(network, burnCred);
 
 /**
  * Interface for objects that can be serialized to CBOR.

--- a/packages/blaze-emulator/src/provider.ts
+++ b/packages/blaze-emulator/src/provider.ts
@@ -11,22 +11,24 @@ import {
   TransactionInput,
   PlutusData,
   TransactionOutput,
+  NetworkId,
 } from "@blaze-cardano/core";
 import { TransactionUnspentOutput } from "@blaze-cardano/core";
-import type { Provider } from "@blaze-cardano/query";
+import { Provider } from "@blaze-cardano/query";
 import type { Emulator } from "./emulator";
 
 /**
  * The EmulatorProvider class implements the Provider interface.
  * It provides methods to interact with the Emulator.
  */
-export class EmulatorProvider implements Provider {
+export class EmulatorProvider extends Provider {
   /**
    * The Emulator instance.
    */
   private emulator: Emulator;
 
   constructor(emulator: Emulator) {
+    super(NetworkId.Testnet);
     this.emulator = emulator;
   }
   getParameters(): Promise<ProtocolParameters> {

--- a/packages/blaze-emulator/test/Emulator.test.ts
+++ b/packages/blaze-emulator/test/Emulator.test.ts
@@ -15,7 +15,6 @@ import {
 import { HotWallet } from "@blaze-cardano/wallet";
 import { Emulator, EmulatorProvider } from "../src";
 import {
-  DEPLOYMENT_ADDR,
   ONE_PLUTUS_DATA,
   VOID_PLUTUS_DATA,
   alwaysTrueScript,
@@ -67,7 +66,8 @@ describe("Emulator", () => {
   });
 
   test("Should be able to pay from one wallet to another", async () => {
-    const tx = await (await blaze.newTransaction())
+    const tx = await blaze
+      .newTransaction()
       .payLovelace(wallet2.address, 2_000_000_000n)
       .complete();
     const txHash = await signAndSubmit(tx, blaze);
@@ -79,9 +79,8 @@ describe("Emulator", () => {
   });
 
   test("Should be able to spend from a script", async () => {
-    const tx = await (
-      await blaze.newTransaction()
-    )
+    const tx = await blaze
+      .newTransaction()
       .lockAssets(
         addressFromCredential(
           NetworkId.Testnet,
@@ -100,9 +99,8 @@ describe("Emulator", () => {
     const out = emulator.getOutput(inp);
     isDefined(out);
     isDefined(out.datum());
-    const spendTx = await (
-      await blaze.newTransaction()
-    )
+    const spendTx = await blaze
+      .newTransaction()
       .addInput(new TransactionUnspentOutput(inp, out), VOID_PLUTUS_DATA)
       .lockAssets(
         addressFromCredential(
@@ -125,25 +123,22 @@ describe("Emulator", () => {
   });
 
   test("Should be able to spend from a script with a reference input", async () => {
-    const refTx = await (await blaze.newTransaction())
-      .lockAssets(
-        DEPLOYMENT_ADDR,
-        makeValue(1_000_000_000n),
-        ONE_PLUTUS_DATA,
-        alwaysTrueScript,
-      )
+    const refTx = await blaze
+      .newTransaction()
+      .deployScript(alwaysTrueScript)
       .complete();
     const refTxHash = await signAndSubmit(refTx, blaze);
     emulator.awaitTransactionConfirmation(refTxHash);
-    const refIn = new TransactionInput(refTxHash, 0n);
-    const refUtxo = new TransactionUnspentOutput(
-      refIn,
-      emulator.getOutput(refIn)!,
-    );
+    const refUtxo = await provider.resolveScriptRef(alwaysTrueScript);
+    isDefined(refUtxo);
+    // const refIn = new TransactionInput(refTxHash, 0n);
+    // const refUtxo = new TransactionUnspentOutput(
+    //   refIn,
+    //   emulator.getOutput(refIn)!
+    // );
 
-    const tx = await (
-      await blaze.newTransaction()
-    )
+    const tx = await blaze
+      .newTransaction()
       .lockAssets(
         addressFromCredential(
           NetworkId.Testnet,
@@ -164,7 +159,8 @@ describe("Emulator", () => {
 
     isDefined(out);
 
-    const spendTx = await (await blaze.newTransaction())
+    const spendTx = await blaze
+      .newTransaction()
       .addInput(new TransactionUnspentOutput(inp, out), VOID_PLUTUS_DATA)
       .addReferenceInput(refUtxo)
       .complete();
@@ -184,7 +180,8 @@ describe("Emulator", () => {
       }),
     );
 
-    const tx = await (await blaze.newTransaction())
+    const tx = await blaze
+      .newTransaction()
       .lockAssets(
         addr,
         makeValue(1_000_000_000n),
@@ -200,7 +197,8 @@ describe("Emulator", () => {
 
     isDefined(out);
 
-    const spendTx = await (await blaze.newTransaction())
+    const spendTx = await blaze
+      .newTransaction()
       .addInput(new TransactionUnspentOutput(inp, out), VOID_PLUTUS_DATA)
       .complete();
     const spendTxHash = await signAndSubmit(spendTx, blaze);
@@ -212,9 +210,8 @@ describe("Emulator", () => {
 
   test("Should be able to mint from a policy", async () => {
     const policy = PolicyId(alwaysTrueScript.hash());
-    const tx = await (
-      await blaze.newTransaction()
-    )
+    const tx = await blaze
+      .newTransaction()
       .addMint(policy, new Map([[AssetName(""), 1n]]), VOID_PLUTUS_DATA)
       .provideScript(alwaysTrueScript)
       .complete();

--- a/packages/blaze-emulator/test/util/index.ts
+++ b/packages/blaze-emulator/test/util/index.ts
@@ -7,16 +7,12 @@ import {
   Transaction,
   TransactionId,
   AddressType,
-  CredentialType,
   HexBlob,
   NetworkId,
   Address,
   Script,
   PlutusV2Script,
   PlutusData,
-  Credential,
-  Hash28ByteBase16,
-  addressFromCredential,
 } from "@blaze-cardano/core";
 import type { Provider } from "@blaze-cardano/query";
 import type { Blaze } from "@blaze-cardano/sdk";
@@ -27,17 +23,6 @@ export const generateSeedPhrase = () => generateMnemonic(wordlist);
 
 export const VOID_PLUTUS_DATA = PlutusData.fromCbor(HexBlob("00"));
 export const ONE_PLUTUS_DATA = PlutusData.fromCbor(HexBlob("01"));
-
-// From https://cardano-tools.io/burn-address
-export const LOCK_SCRIPT_HASH =
-  "bbece14f554b0020fe2715d05801f4680ebd40d11a58f14740b9f2c5";
-export const DEPLOYMENT_ADDR = addressFromCredential(
-  NetworkId.Testnet,
-  Credential.fromCore({
-    hash: Hash28ByteBase16(LOCK_SCRIPT_HASH),
-    type: CredentialType.ScriptHash,
-  }),
-);
 
 export const SAMPLE_PLUTUS_DATA = PlutusData.fromCore(
   new Uint8Array([1, 2, 3]),

--- a/packages/blaze-ogmios/src/unwrapped.ts
+++ b/packages/blaze-ogmios/src/unwrapped.ts
@@ -2,8 +2,8 @@ import WebSocket from "isomorphic-ws";
 import type * as schema from "./schema";
 
 export class Ogmios {
+  url: string;
   private ws: WebSocket;
-  private url: string;
   private requests: Record<
     string,
     { resolve: (value: any) => void; reject: (reason: any) => void }

--- a/packages/blaze-query/src/blockfrost.ts
+++ b/packages/blaze-query/src/blockfrost.ts
@@ -19,6 +19,7 @@ import {
   hardCodedProtocolParams,
   Hash28ByteBase16,
   HexBlob,
+  NetworkId,
   PlutusData,
   PlutusV1Script,
   PlutusV2Script,
@@ -31,9 +32,9 @@ import {
   Value,
 } from "@blaze-cardano/core";
 import { PlutusLanguageVersion } from "@blaze-cardano/core";
-import { purposeToTag, type Provider } from "./types";
+import { purposeToTag, Provider } from "./provider";
 
-export class Blockfrost implements Provider {
+export class Blockfrost extends Provider {
   url: string;
   private projectId: string;
 
@@ -48,6 +49,7 @@ export class Blockfrost implements Provider {
       | "cardano-sanchonet";
     projectId: string;
   }) {
+    super(network == "cardano-mainnet" ? NetworkId.Mainnet : NetworkId.Testnet);
     this.url = `https://${network}.blockfrost.io/api/v0/`;
     this.projectId = projectId;
   }

--- a/packages/blaze-query/src/index.ts
+++ b/packages/blaze-query/src/index.ts
@@ -1,4 +1,4 @@
 export * from "./maestro";
 export * from "./blockfrost";
 export * from "./kupmios";
-export * from "./types";
+export * from "./provider";

--- a/packages/blaze-query/src/kupmios.ts
+++ b/packages/blaze-query/src/kupmios.ts
@@ -25,12 +25,13 @@ import {
   PlutusV1Script,
   PlutusV2Script,
   PlutusV3Script,
+  NetworkId,
 } from "@blaze-cardano/core";
-import { purposeToTag, type Provider } from "./types";
+import { purposeToTag, Provider } from "./provider";
 import type { Unwrapped } from "@blaze-cardano/ogmios";
 import type * as Schema from "@cardano-ogmios/schema";
 
-export class Kupmios implements Provider {
+export class Kupmios extends Provider {
   kupoUrl: string;
   ogmios: Unwrapped.Ogmios;
 
@@ -48,6 +49,9 @@ export class Kupmios implements Provider {
    * @param ogmiosUrl - URL of the Ogmios service.
    */
   constructor(kupoUrl: string, ogmios: Unwrapped.Ogmios) {
+    super(
+      ogmios.url.includes("mainnet-v6") ? NetworkId.Mainnet : NetworkId.Testnet,
+    );
     this.kupoUrl = kupoUrl;
     this.ogmios = ogmios;
   }

--- a/packages/blaze-query/src/maestro.ts
+++ b/packages/blaze-query/src/maestro.ts
@@ -6,7 +6,7 @@ import type {
   CostModels,
   Credential,
 } from "@blaze-cardano/core";
-import { RedeemerTag } from "@blaze-cardano/core";
+import { NetworkId, RedeemerTag } from "@blaze-cardano/core";
 import {
   TransactionUnspentOutput,
   Address,
@@ -21,9 +21,9 @@ import {
   Redeemers,
   ExUnits,
 } from "@blaze-cardano/core";
-import type { Provider } from "./types";
+import { Provider } from "./provider";
 
-export class Maestro implements Provider {
+export class Maestro extends Provider {
   private url: string;
   private apiKey: string;
 
@@ -34,6 +34,7 @@ export class Maestro implements Provider {
     network: "mainnet" | "preview" | "preprod";
     apiKey: string;
   }) {
+    super(network == "mainnet" ? NetworkId.Mainnet : NetworkId.Testnet);
     this.url = `https://${network}.gomaestro-api.org/v1`;
     this.apiKey = apiKey;
   }

--- a/packages/blaze-query/src/provider.ts
+++ b/packages/blaze-query/src/provider.ts
@@ -122,21 +122,21 @@ export abstract class Provider {
    * Resolves the script deployment by finding a UTxO containing the script reference.
    *
    * @param {Script | Hash28ByteBase16} script - The script or its hash to resolve.
-   * @param {Address} [address] - The address to search for the script deployment. Defaults to the burn address on Mainnet.
+   * @param {Address} [address] - The address to search for the script deployment. Defaults to a burn address.
    * @returns {Promise<TransactionUnspentOutput | undefined>} - The UTxO containing the script reference, or undefined if not found.
    *
    * @remarks
    * This is a default implementation that works but may not be optimal.
    * Subclasses of Provider should implement their own version for better performance.
    *
-   * The method searches for a UTxO at the given address (or the Blaze Mainnet burn address by default)
+   * The method searches for a UTxO at the given address (or a burn address by default)
    * that contains a script reference matching the provided script or script hash.
    *
    * @example
    * ```typescript
    * const scriptUtxo = await provider.resolveScriptRef(myScript);
    * if (scriptUtxo) {
-   *   console.log("Script found in UTxO:", scriptUtxo.txId());
+   *   console.log("Script found in UTxO:", scriptUtxo.input().toCore());
    * } else {
    *   console.log("Script not found");
    * }

--- a/packages/blaze-query/src/provider.ts
+++ b/packages/blaze-query/src/provider.ts
@@ -9,8 +9,12 @@ import {
   type Transaction,
   type ProtocolParameters,
   type Redeemers,
+  type NetworkId,
+  type Hash28ByteBase16,
   RedeemerPurpose,
   RedeemerTag,
+  Script,
+  getBurnAddress,
 } from "@blaze-cardano/core";
 
 /**
@@ -18,6 +22,12 @@ import {
  * This class provides an interface for interacting with the blockchain.
  */
 export abstract class Provider {
+  network: NetworkId;
+
+  constructor(network: NetworkId) {
+    this.network = network;
+  }
+
   /**
    * Retrieves the parameters for a transaction.
    *
@@ -107,6 +117,41 @@ export abstract class Provider {
     tx: Transaction,
     additionalUtxos: TransactionUnspentOutput[],
   ): Promise<Redeemers>;
+
+  /**
+   * Resolves the script deployment by finding a UTxO containing the script reference.
+   *
+   * @param {Script | Hash28ByteBase16} script - The script or its hash to resolve.
+   * @param {Address} [address] - The address to search for the script deployment. Defaults to the burn address on Mainnet.
+   * @returns {Promise<TransactionUnspentOutput | undefined>} - The UTxO containing the script reference, or undefined if not found.
+   *
+   * @remarks
+   * This is a default implementation that works but may not be optimal.
+   * Subclasses of Provider should implement their own version for better performance.
+   *
+   * The method searches for a UTxO at the given address (or the Blaze Mainnet burn address by default)
+   * that contains a script reference matching the provided script or script hash.
+   *
+   * @example
+   * ```typescript
+   * const scriptUtxo = await provider.resolveScriptRef(myScript);
+   * if (scriptUtxo) {
+   *   console.log("Script found in UTxO:", scriptUtxo.txId());
+   * } else {
+   *   console.log("Script not found");
+   * }
+   * ```
+   */
+  async resolveScriptRef(
+    script: Script | Hash28ByteBase16,
+    address: Address = getBurnAddress(this.network),
+  ): Promise<TransactionUnspentOutput | undefined> {
+    const utxos = await this.getUnspentOutputs(address);
+    if (script instanceof Script) {
+      script = script.hash();
+    }
+    return utxos.find((utxo) => utxo.output().scriptRef()?.hash() === script);
+  }
 }
 
 /**

--- a/packages/blaze-tx/src/tx.ts
+++ b/packages/blaze-tx/src/tx.ts
@@ -750,7 +750,7 @@ export class TxBuilder {
    *
    * @example
    * ```typescript
-   * const myScript = new PlutusV2Script("...");
+   * const myScript = Script.newPlutusV2Script(new PlutusV2Script("..."));
    * txBuilder.deployScript(myScript);
    * // or
    * txBuilder.deployScript(myScript, someAddress);

--- a/packages/blaze-tx/src/tx.ts
+++ b/packages/blaze-tx/src/tx.ts
@@ -135,7 +135,7 @@ export class TxBuilder {
   private feePadding: bigint = 0n; // A padding to add onto the fee; use only in emergencies, and open a ticket so we can fix the fee calculation please!
   private coinSelector: (
     inputs: TransactionUnspentOutput[],
-    dearth: Value
+    dearth: Value,
   ) => SelectionResult = micahsSelector;
   private _burnAddress?: Address;
 
@@ -149,7 +149,7 @@ export class TxBuilder {
       CborSet.fromCore([], TransactionInput.fromCore),
       [],
       0n,
-      undefined
+      undefined,
     );
   }
 
@@ -234,8 +234,8 @@ export class TxBuilder {
   useCoinSelector(
     selector: (
       inputs: TransactionUnspentOutput[],
-      dearth: Value
-    ) => SelectionResult
+      dearth: Value,
+    ) => SelectionResult,
   ): TxBuilder {
     this.coinSelector = selector;
     return this;
@@ -310,12 +310,12 @@ export class TxBuilder {
       values.find(
         (val) =>
           val.index() == utxo.input().index() &&
-          val.transactionId() == utxo.input().transactionId()
+          val.transactionId() == utxo.input().transactionId(),
       )
     ) {
       // If a duplicate is found, throw an error to prevent adding it.
       throw new Error(
-        "Cannot add duplicate reference input to the transaction"
+        "Cannot add duplicate reference input to the transaction",
       );
     }
     // If no duplicate is found, add the input to the array of reference inputs.
@@ -350,7 +350,7 @@ export class TxBuilder {
   addInput(
     utxo: TransactionUnspentOutput,
     redeemer?: PlutusData,
-    unhashDatum?: PlutusData
+    unhashDatum?: PlutusData,
   ): TxBuilder {
     // Retrieve the current inputs from the transaction body for manipulation.
     const inputs = this.body.inputs();
@@ -360,7 +360,7 @@ export class TxBuilder {
       values.find(
         (val) =>
           val.index() == utxo.input().index() &&
-          val.transactionId() == utxo.input().transactionId()
+          val.transactionId() == utxo.input().transactionId(),
       )
     ) {
       throw new Error("Cannot add duplicate input to the transaction");
@@ -392,25 +392,25 @@ export class TxBuilder {
     if (redeemer !== undefined) {
       if (key.type == CredentialType.KeyHash) {
         throw new Error(
-          "addInput: Cannot spend with redeemer for KeyHash credential!"
+          "addInput: Cannot spend with redeemer for KeyHash credential!",
         );
       }
       this.requiredPlutusScripts.add(key.hash);
       const datum = utxo.output().datum();
       if (!datum) {
         throw new Error(
-          "addInput: Cannot spend with redeemer when datum is missing!"
+          "addInput: Cannot spend with redeemer when datum is missing!",
         );
       }
       if (datum?.asInlineData() && unhashDatum) {
         throw new Error(
-          "addInput: Cannot have inline datum and also provided datum (3rd arg)."
+          "addInput: Cannot have inline datum and also provided datum (3rd arg).",
         );
       }
       if (datum?.asDataHash()) {
         if (!unhashDatum) {
           throw new Error(
-            "addInput: When spending datum hash, must provide datum (3rd arg)."
+            "addInput: When spending datum hash, must provide datum (3rd arg).",
           );
         }
         this.plutusData.add(unhashDatum!);
@@ -425,7 +425,7 @@ export class TxBuilder {
             memory: this.params.maxExecutionUnitsPerTransaction.memory,
             steps: this.params.maxExecutionUnitsPerTransaction.steps,
           },
-        })
+        }),
       );
       this.redeemers.setValues(redeemers);
     } else {
@@ -487,11 +487,11 @@ export class TxBuilder {
   addMint(
     policy: PolicyId,
     assets: Map<AssetName, bigint>,
-    redeemer?: PlutusData
+    redeemer?: PlutusData,
   ) {
     const insertIdx = this.insertSorted(
       this.consumedMintHashes,
-      PolicyIdToHash(policy)
+      PolicyIdToHash(policy),
     );
     // Retrieve the current mint map from the transaction body, or initialize a new one if none exists.
     const mint: TokenMap = this.body.mint() ?? new Map();
@@ -533,7 +533,7 @@ export class TxBuilder {
             memory: this.params.maxExecutionUnitsPerTransaction.memory, // Placeholder memory units, replace with actual estimation.
             steps: this.params.maxExecutionUnitsPerTransaction.steps, // Placeholder step units, replace with actual estimation.
           },
-        })
+        }),
       );
       // Update the transaction's redeemers with the new list.
       this.redeemers.setValues(redeemers);
@@ -645,7 +645,7 @@ export class TxBuilder {
         value: { coins: lovelace },
         datum: datumData,
         datumHash,
-      })
+      }),
     );
     return this;
   }
@@ -671,7 +671,7 @@ export class TxBuilder {
         value: value.toCore(),
         datum: datumData,
         datumHash,
-      })
+      }),
     );
     return this;
   }
@@ -692,13 +692,13 @@ export class TxBuilder {
     address: Address,
     lovelace: bigint,
     datum: Datum,
-    scriptReference?: Script
+    scriptReference?: Script,
   ): TxBuilder {
     return this.lockAssets(
       address,
       new Value(lovelace),
       datum,
-      scriptReference
+      scriptReference,
     );
   }
 
@@ -718,7 +718,7 @@ export class TxBuilder {
     address: Address,
     value: Value,
     datum: Datum,
-    scriptReference?: Script
+    scriptReference?: Script,
   ): TxBuilder {
     const datumData = typeof datum == "object" ? datum.toCore() : undefined;
     const datumHash = typeof datum == "string" ? datum : undefined;
@@ -731,7 +731,7 @@ export class TxBuilder {
         datum: datumData,
         datumHash,
         scriptReference: scriptReference?.toCore(),
-      })
+      }),
     );
   }
 
@@ -784,7 +784,7 @@ export class TxBuilder {
   private async evaluate(draft_tx: Transaction): Promise<bigint> {
     // Collect all UTXOs from the transaction's scope.
     const allUtxos: TransactionUnspentOutput[] = Array.from(
-      this.utxoScope.values()
+      this.utxoScope.values(),
     );
     // todo: filter utxoscope to only include inputs, reference inputs, collateral inputs, not excess junk
 
@@ -833,7 +833,7 @@ export class TxBuilder {
         const script = scriptLookup[requiredScriptHash];
         if (!script) {
           throw new Error(
-            `complete: Could not resolve script hash ${requiredScriptHash}`
+            `complete: Could not resolve script hash ${requiredScriptHash}`,
           );
         } else {
           if (script.asNative() != undefined) {
@@ -860,7 +860,7 @@ export class TxBuilder {
         this.usedLanguages[PlutusLanguageVersion.V3] = true;
       } else if (!lang) {
         throw new Error(
-          "buildTransactionWitnessSet: lang script lookup failed"
+          "buildTransactionWitnessSet: lang script lookup failed",
         );
       }
     }
@@ -870,14 +870,14 @@ export class TxBuilder {
         const script = scriptLookup[requiredScriptHash];
         if (!script) {
           throw new Error(
-            `complete: Could not resolve script hash ${requiredScriptHash}`
+            `complete: Could not resolve script hash ${requiredScriptHash}`,
           );
         } else {
           if (script.asNative() != undefined) {
             sn.push(script.asNative()!);
           } else {
             throw new Error(
-              "complete: Could not resolve script hash (was not native script)"
+              "complete: Could not resolve script hash (was not native script)",
             );
           }
         }
@@ -912,7 +912,7 @@ export class TxBuilder {
         (_, i) => [
           Ed25519PublicKeyHex(i.toString().padStart(64, "0")),
           Ed25519SignatureHex(i.toString().padStart(128, "0")),
-        ]
+        ],
       );
 
     tw.setVkeys(CborSet.fromCore(requiredWitnesses, VkeyWitness.fromCore));
@@ -983,20 +983,20 @@ export class TxBuilder {
         case 0: // Stake Registration
           outputValue = value.merge(
             outputValue,
-            new Value(BigInt(this.params.stakeKeyDeposit))
+            new Value(BigInt(this.params.stakeKeyDeposit)),
           );
           break;
         case 1: // Stake Deregistration
           inputValue = value.merge(
             inputValue,
-            new Value(BigInt(this.params.stakeKeyDeposit))
+            new Value(BigInt(this.params.stakeKeyDeposit)),
           );
           break;
         case 3: // Pool Registration
           if (this.params.poolDeposit) {
             outputValue = value.merge(
               outputValue,
-              new Value(BigInt(this.params.poolDeposit))
+              new Value(BigInt(this.params.poolDeposit)),
             );
           }
           break;
@@ -1004,7 +1004,7 @@ export class TxBuilder {
           if (this.params.poolDeposit) {
             inputValue = value.merge(
               inputValue,
-              new Value(BigInt(this.params.poolDeposit))
+              new Value(BigInt(this.params.poolDeposit)),
             );
           }
           break;
@@ -1015,14 +1015,14 @@ export class TxBuilder {
     // Subtract a fixed fee amount (5 ADA) to ensure enough is allocated for transaction fees.
     const tilt = value.merge(
       value.merge(inputValue, value.negate(outputValue)),
-      mintValue
+      mintValue,
     );
     if (spareAmount != 0n) {
       return value.merge(tilt, new Value(-spareAmount)); // Subtract 5 ADA from the excess.
     }
     return value.merge(
       tilt,
-      this.body.outputs()[this.changeOutputIndex!]!.amount()
+      this.body.outputs()[this.changeOutputIndex!]!.amount(),
     );
   }
 
@@ -1067,20 +1067,20 @@ export class TxBuilder {
         case 0: // Stake Registration
           outputValue = value.merge(
             outputValue,
-            new Value(BigInt(this.params.stakeKeyDeposit))
+            new Value(BigInt(this.params.stakeKeyDeposit)),
           );
           break;
         case 1: // Stake Deregistration
           inputValue = value.merge(
             inputValue,
-            new Value(BigInt(this.params.stakeKeyDeposit))
+            new Value(BigInt(this.params.stakeKeyDeposit)),
           );
           break;
         case 3: // Pool Registration
           if (this.params.poolDeposit) {
             outputValue = value.merge(
               outputValue,
-              new Value(BigInt(this.params.poolDeposit))
+              new Value(BigInt(this.params.poolDeposit)),
             );
           }
           break;
@@ -1088,7 +1088,7 @@ export class TxBuilder {
           if (this.params.poolDeposit) {
             inputValue = value.merge(
               inputValue,
-              new Value(BigInt(this.params.poolDeposit))
+              new Value(BigInt(this.params.poolDeposit)),
             );
           }
           break;
@@ -1096,7 +1096,7 @@ export class TxBuilder {
     }
     const tilt = value.merge(
       value.merge(inputValue, value.negate(outputValue)),
-      mintValue
+      mintValue,
     );
     return tilt.toCbor() == value.zero().toCbor();
   }
@@ -1109,7 +1109,7 @@ export class TxBuilder {
    * @returns {Hash32ByteBase16 | undefined} The script data hash if datums or redeemers are present, otherwise undefined.
    */
   private getScriptDataHash(
-    tw: TransactionWitnessSet
+    tw: TransactionWitnessSet,
   ): Hash32ByteBase16 | undefined {
     // Extract redeemers and datums from the transaction witness set.
     const redeemers = [...this.redeemers.values()];
@@ -1149,7 +1149,7 @@ export class TxBuilder {
           // Throw an error if the cost model is missing.
           if (cm == undefined) {
             throw new Error(
-              `complete: Could not find cost model for Plutus Language Version ${i}`
+              `complete: Could not find cost model for Plutus Language Version ${i}`,
             );
           }
           // Insert the cost model into the used cost models container.
@@ -1158,7 +1158,7 @@ export class TxBuilder {
       }
       // Encode the used cost models into CBOR format.
       writer.writeEncodedValue(
-        Buffer.from(usedCostModels.languageViewsEncoding(), "hex")
+        Buffer.from(usedCostModels.languageViewsEncoding(), "hex"),
       );
       // Generate and return the script data hash.
       return blake2b_256(writer.encodeAsHex());
@@ -1226,7 +1226,7 @@ export class TxBuilder {
           utxoScope
             .find((y) => y.input().toCbor() == x.toCbor())!
             .output()
-            .scriptRef()
+            .scriptRef(),
         )
         .filter((x) => x !== undefined);
       if (refScripts.length > 0) {
@@ -1247,7 +1247,7 @@ export class TxBuilder {
     // Retrieve provided collateral inputs
     const providedCollateral = [...this.collateralUtxos.values()].sort(
       (a, b) =>
-        a.output().amount().coin() < b.output().amount().coin() ? -1 : 1
+        a.output().amount().coin() < b.output().amount().coin() ? -1 : 1,
     );
     // Retrieve inputs from the transaction body and available UTXOs within scope.
     const inputs = [...this.body.inputs().values()];
@@ -1284,7 +1284,7 @@ export class TxBuilder {
         const utxo = scope.find(
           (x) =>
             x.input().transactionId() === input.transactionId() &&
-            x.input().index() === input.index()
+            x.input().index() === input.index(),
         );
 
         if (utxo) {
@@ -1352,7 +1352,7 @@ export class TxBuilder {
         if (adaAmount < 5_000_000n) {
           // create a sorted list of utxos by ada amount
           const adaUtxos = [...this.utxos.values()].sort((a, b) =>
-            a.output().amount().coin() < b.output().amount().coin() ? -1 : 1
+            a.output().amount().coin() < b.output().amount().coin() ? -1 : 1,
           );
           for (
             let i = 0;
@@ -1368,7 +1368,7 @@ export class TxBuilder {
         }
         if (adaAmount <= 5_000_000) {
           throw new Error(
-            "prepareCollateral: could not find enough collateral (5 ada minimum)"
+            "prepareCollateral: could not find enough collateral (5 ada minimum)",
           );
         }
         best = collateral;
@@ -1392,8 +1392,8 @@ export class TxBuilder {
       this.collateralChangeAddress ?? this.changeAddress!,
       best.reduce(
         (acc, x) => value.merge(acc, x.output().amount()),
-        value.zero()
-      )
+        value.zero(),
+      ),
     );
     this.body.setCollateralReturn(ret);
   }
@@ -1425,7 +1425,7 @@ export class TxBuilder {
     for (const [asset, qty] of Array.from(multiAsset.entries())) {
       const newOutputValue = value.merge(
         output.amount(),
-        value.makeValue(0n, [asset, qty])
+        value.makeValue(0n, [asset, qty]),
       );
       const newOutputValueByteLength = newOutputValue.toCbor().length / 2;
       //We need to check if the new output value is too large
@@ -1435,7 +1435,7 @@ export class TxBuilder {
         changeExcess = value.sub(changeExcess, output.amount());
         output = new TransactionOutput(
           this.changeAddress!,
-          value.makeValue(0n, [asset, qty])
+          value.makeValue(0n, [asset, qty]),
         );
       } else {
         output = new TransactionOutput(this.changeAddress!, newOutputValue);
@@ -1468,8 +1468,8 @@ export class TxBuilder {
     const totalCollateral = BigInt(
       Math.ceil(
         (this.params.collateralPercentage / 100) *
-          Number(bigintMax(this.fee, this.minimumFee) + this.feePadding)
-      )
+          Number(bigintMax(this.fee, this.minimumFee) + this.feePadding),
+      ),
     );
     // Calculate the collateral value by summing up the amounts from collateral inputs.
     const collateralValue = this.body
@@ -1479,11 +1479,11 @@ export class TxBuilder {
         const utxo = scope.find(
           (x) =>
             x.input().transactionId() === input.transactionId() &&
-            x.input().index() === input.index()
+            x.input().index() === input.index(),
         );
         if (!utxo) {
           throw new Error(
-            "balanceCollateralChange: Could not resolve some collateral input"
+            "balanceCollateralChange: Could not resolve some collateral input",
           );
         }
         return value.merge(utxo.output().amount(), acc);
@@ -1492,8 +1492,8 @@ export class TxBuilder {
     this.body.setCollateralReturn(
       new TransactionOutput(
         this.changeAddress,
-        value.merge(collateralValue, new Value(-totalCollateral))
-      )
+        value.merge(collateralValue, new Value(-totalCollateral)),
+      ),
     );
     // Update the transaction body with the total collateral amount.
     this.body.setTotalCollateral(totalCollateral);
@@ -1532,12 +1532,12 @@ export class TxBuilder {
     // Ensure a change address has been set before proceeding.
     if (!this.changeAddress) {
       throw new Error(
-        "Cannot complete transaction without setting change address"
+        "Cannot complete transaction without setting change address",
       );
     }
     if (this.networkId === undefined) {
       throw new Error(
-        "Cannot complete transaction without setting a network id"
+        "Cannot complete transaction without setting a network id",
       );
     }
     // TODO: Potential bug with js SDK where setting the network to testnet causes the tx body CBOR to fail
@@ -1548,14 +1548,14 @@ export class TxBuilder {
     // Perform initial checks and preparations for coin selection.
     const preliminaryDraftTx = new Transaction(
       this.body,
-      new TransactionWitnessSet()
+      new TransactionWitnessSet(),
     );
     const preliminaryFee =
       this.params.minFeeConstant +
       fromHex(preliminaryDraftTx.toCbor()).length *
         this.params.minFeeCoefficient;
     let excessValue = this.getPitch(
-      bigintMax(BigInt(Math.ceil(preliminaryFee)), this.minimumFee)
+      bigintMax(BigInt(Math.ceil(preliminaryFee)), this.minimumFee),
     );
     let spareInputs: TransactionUnspentOutput[] = [];
     for (const [utxo] of this.utxos.entries()) {
@@ -1566,7 +1566,7 @@ export class TxBuilder {
     // Perform coin selection to cover any negative excess value.
     const selectionResult = this.coinSelector(
       spareInputs,
-      value.negate(value.negatives(excessValue))
+      value.negate(value.negatives(excessValue)),
     );
     // Update the excess value and spare inputs based on the selection result.
     excessValue = value.merge(excessValue, selectionResult.selectedValue);
@@ -1580,37 +1580,37 @@ export class TxBuilder {
       if (this.body.inputs().size() == 0) {
         if (!spareInputs[0]) {
           throw new Error(
-            "No spare inputs available to add to the transaction"
+            "No spare inputs available to add to the transaction",
           );
         }
         // Select the input with the least number of different multiassets from spareInputs
         const [inputWithLeastMultiAssets] = spareInputs.reduce(
           ([minInput, minMultiAssetCount], currentInput) => {
             const currentMultiAssetCount = value.assetTypes(
-              currentInput.output().amount()
+              currentInput.output().amount(),
             );
             return currentMultiAssetCount < minMultiAssetCount
               ? [currentInput, minMultiAssetCount]
               : [minInput, value.assetTypes(minInput.output().amount())];
           },
-          [spareInputs[0], value.assetTypes(spareInputs[0].output().amount())]
+          [spareInputs[0], value.assetTypes(spareInputs[0].output().amount())],
         );
         this.addInput(inputWithLeastMultiAssets);
         // Remove the selected input from spareInputs
         spareInputs = spareInputs.filter(
-          (input) => input !== inputWithLeastMultiAssets
+          (input) => input !== inputWithLeastMultiAssets,
         );
       }
     }
     if (this.body.inputs().values().length == 0) {
       throw new Error(
-        "TxBuilder: resolved empty input set, cannot construct transaction!"
+        "TxBuilder: resolved empty input set, cannot construct transaction!",
       );
     }
     // Ensure the coin selection has eliminated all negative values.
     if (!value.empty(value.negatives(excessValue))) {
       throw new Error(
-        "Unreachable! Somehow coin selection succeeded but still failed."
+        "Unreachable! Somehow coin selection succeeded but still failed.",
       );
     }
 
@@ -1621,7 +1621,7 @@ export class TxBuilder {
     // Ensure a change output index has been set after balancing.
     if (this.changeOutputIndex === undefined) {
       throw new Error(
-        "Unreachable! Somehow change balancing succeeded but still failed."
+        "Unreachable! Somehow change balancing succeeded but still failed.",
       );
     }
     // Build the transaction witness set for fee estimation and script validation.
@@ -1640,13 +1640,13 @@ export class TxBuilder {
       const auxiliaryDataHash = this.getAuxiliaryDataHash(auxiliaryData);
       if (auxiliaryDataHash != this.body.auxiliaryDataHash()) {
         throw new Error(
-          "TxBuilder complete: auxiliary data somehow didn't match auxiliary data hash"
+          "TxBuilder complete: auxiliary data somehow didn't match auxiliary data hash",
         );
       }
     } else {
       if (this.body.auxiliaryDataHash() != undefined) {
         throw new Error(
-          "TxBuilder complete: auxiliary data somehow didn't match auxiliary data hash"
+          "TxBuilder complete: auxiliary data somehow didn't match auxiliary data hash",
         );
       }
     }
@@ -1660,8 +1660,8 @@ export class TxBuilder {
       excessValue,
       new Value(
         -(bigintMax(this.fee, this.minimumFee) + this.feePadding) +
-          BigInt(preliminaryFee)
-      )
+          BigInt(preliminaryFee),
+      ),
     );
     this.balanceChange(excessValue);
     let evaluationFee: bigint = 0n;
@@ -1672,7 +1672,7 @@ export class TxBuilder {
         evaluationFee = await this.evaluate(draft_tx);
       } catch (e) {
         console.log(
-          `An error occurred when trying to evaluate this transaction. Full CBOR: ${draft_tx.toCbor()}`
+          `An error occurred when trying to evaluate this transaction. Full CBOR: ${draft_tx.toCbor()}`,
         );
         throw e;
       }
@@ -1698,14 +1698,14 @@ export class TxBuilder {
     }
     if (this.feePadding > 0n) {
       console.warn(
-        "A transaction was built using fee padding. This is useful for working around changes to fee calculation, but ultimately is a bandaid. If you find yourself needing this, please open a ticket at https://github.com/butaneprotocol/blaze-cardano so we can fix the underlying inaccuracy!"
+        "A transaction was built using fee padding. This is useful for working around changes to fee calculation, but ultimately is a bandaid. If you find yourself needing this, please open a ticket at https://github.com/butaneprotocol/blaze-cardano so we can fix the underlying inaccuracy!",
       );
     }
     let final_size = draft_size;
     do {
       const oldEvaluationFee = evaluationFee;
       this.fee += BigInt(
-        Math.ceil((final_size - draft_size) * this.params.minFeeCoefficient)
+        Math.ceil((final_size - draft_size) * this.params.minFeeCoefficient),
       );
       excessValue = this.getPitch();
 
@@ -1715,7 +1715,7 @@ export class TxBuilder {
       if (changeOutput.amount().coin() > excessValue.coin()) {
         const excessDifference = value.merge(
           changeOutput!.amount(),
-          value.negate(excessValue)
+          value.negate(excessValue),
         );
         // we must add more inputs, to cover the difference
         if (spareInputs.length == 0) {
@@ -1723,7 +1723,7 @@ export class TxBuilder {
         }
         const selectionResult = this.coinSelector(
           spareInputs,
-          excessDifference
+          excessDifference,
         );
         spareInputs = selectionResult.inputs;
         for (const input of selectionResult.selectedInputs) {
@@ -1769,7 +1769,7 @@ export class TxBuilder {
   addDelegation(
     delegator: Credential,
     poolId: PoolId,
-    redeemer?: PlutusData
+    redeemer?: PlutusData,
   ): TxBuilder {
     const stakeDelegation: StakeDelegationCertificate = {
       __typename: CertificateType.StakeDelegation,
@@ -1777,7 +1777,7 @@ export class TxBuilder {
       poolId: poolId,
     };
     const delegationCertificate: Certificate = Certificate.newStakeDelegation(
-      StakeDelegation.fromCore(stakeDelegation)
+      StakeDelegation.fromCore(stakeDelegation),
     );
     const certs =
       this.body.certs() ?? CborSet.fromCore([], Certificate.fromCore);
@@ -1798,7 +1798,7 @@ export class TxBuilder {
               memory: this.params.maxExecutionUnitsPerTransaction.memory,
               steps: this.params.maxExecutionUnitsPerTransaction.steps,
             },
-          })
+          }),
         );
         this.redeemers.setValues(redeemers);
       } else {
@@ -1806,7 +1806,7 @@ export class TxBuilder {
       }
     } else if (redeemer) {
       throw new Error(
-        "TxBuilder addDelegation: failing to attach redeemer to a non-script delegation!"
+        "TxBuilder addDelegation: failing to attach redeemer to a non-script delegation!",
       );
     } else {
       this.requiredWitnesses.add(HashAsPubKeyHex(delegatorCredential.hash));
@@ -1829,7 +1829,7 @@ export class TxBuilder {
     const credential = this.rewardAddress!.getProps().delegationPart;
     if (!credential) {
       throw new Error(
-        "TxBuilder delegate: Somehow the reward address had no stake component"
+        "TxBuilder delegate: Somehow the reward address had no stake component",
       );
     }
     this.addDelegation(Credential.fromCore(credential), poolId, redeemer);
@@ -1843,7 +1843,7 @@ export class TxBuilder {
    */
   addRegisterStake(credential: Credential) {
     const stakeRegistration: StakeRegistration = new StakeRegistration(
-      credential.toCore()
+      credential.toCore(),
     );
     const registrationCertificate: Certificate =
       Certificate.newStakeRegistration(stakeRegistration);
@@ -1889,7 +1889,7 @@ export class TxBuilder {
   setValidFrom(validFrom: Slot): TxBuilder {
     if (this.body.validityStartInterval() !== undefined) {
       throw new Error(
-        "TxBuilder setValidFrom: Validity start interval is already set"
+        "TxBuilder setValidFrom: Validity start interval is already set",
       );
     }
     this.body.setValidityStartInterval(validFrom);
@@ -1924,18 +1924,18 @@ export class TxBuilder {
   addWithdrawal(
     address: RewardAccount,
     amount: bigint,
-    redeemer?: PlutusData
+    redeemer?: PlutusData,
   ): TxBuilder {
     const withdrawalHash =
       Address.fromBech32(address).getProps().paymentPart?.hash;
     if (!withdrawalHash) {
       throw new Error(
-        "addWithdrawal: The RewardAccount provided does not have an associated stake credential."
+        "addWithdrawal: The RewardAccount provided does not have an associated stake credential.",
       );
     }
     const insertIdx = this.insertSorted(
       this.consumedWithdrawalHashes,
-      withdrawalHash
+      withdrawalHash,
     );
     // Retrieve existing withdrawals or initialize a new map if none exist.
     const withdrawals: Map<RewardAccount, bigint> =
@@ -1943,7 +1943,7 @@ export class TxBuilder {
     // Sanity check duplicates
     if (withdrawals.has(address)) {
       throw new Error(
-        "addWithdrawal: Withdrawal for this address already exists."
+        "addWithdrawal: Withdrawal for this address already exists.",
       );
     }
     // Set the withdrawal amount for the specified address.
@@ -1972,7 +1972,7 @@ export class TxBuilder {
             memory: this.params.maxExecutionUnitsPerTransaction.memory,
             steps: this.params.maxExecutionUnitsPerTransaction.steps,
           },
-        })
+        }),
       );
       // Update the transaction with the new list of redeemers.
       this.redeemers.setValues(redeemers);
@@ -1981,7 +1981,7 @@ export class TxBuilder {
       const key = Address.fromBech32(address).getProps().paymentPart;
       if (!key) {
         throw new Error(
-          "addWithdrawal: The RewardAccount provided does not have an associated stake credential."
+          "addWithdrawal: The RewardAccount provided does not have an associated stake credential.",
         );
       }
       // Add the required scripts or witnesses based on the type of the stake credential.
@@ -2022,7 +2022,7 @@ export class TxBuilder {
    * @returns {Hash32ByteBase16 | undefined} The hash of the auxiliary data or undefined if no auxiliary data is provided.
    */
   private getAuxiliaryDataHash(
-    auxiliaryData: AuxiliaryData
+    auxiliaryData: AuxiliaryData,
   ): Hash32ByteBase16 | undefined {
     return auxiliaryData ? blake2b_256(auxiliaryData.toCbor()) : undefined;
   }
@@ -2088,7 +2088,7 @@ function assertPaymentsAddress(address: Address) {
   }
   if (props.paymentPart.type == CredentialType.ScriptHash) {
     throw new Error(
-      "assertPaymentsAddress: address payment credential cannot be a script hash!"
+      "assertPaymentsAddress: address payment credential cannot be a script hash!",
     );
   }
 }
@@ -2105,7 +2105,7 @@ function assertLockAddress(address: Address) {
   }
   if (props.paymentPart.type != CredentialType.ScriptHash) {
     throw new Error(
-      "assertLockAddress: address payment credential must be a script hash!"
+      "assertLockAddress: address payment credential must be a script hash!",
     );
   }
 }

--- a/packages/blaze-tx/src/tx.ts
+++ b/packages/blaze-tx/src/tx.ts
@@ -135,7 +135,7 @@ export class TxBuilder {
   private feePadding: bigint = 0n; // A padding to add onto the fee; use only in emergencies, and open a ticket so we can fix the fee calculation please!
   private coinSelector: (
     inputs: TransactionUnspentOutput[],
-    dearth: Value,
+    dearth: Value
   ) => SelectionResult = micahsSelector;
   private _burnAddress?: Address;
 
@@ -149,7 +149,7 @@ export class TxBuilder {
       CborSet.fromCore([], TransactionInput.fromCore),
       [],
       0n,
-      undefined,
+      undefined
     );
   }
 
@@ -234,8 +234,8 @@ export class TxBuilder {
   useCoinSelector(
     selector: (
       inputs: TransactionUnspentOutput[],
-      dearth: Value,
-    ) => SelectionResult,
+      dearth: Value
+    ) => SelectionResult
   ): TxBuilder {
     this.coinSelector = selector;
     return this;
@@ -310,12 +310,12 @@ export class TxBuilder {
       values.find(
         (val) =>
           val.index() == utxo.input().index() &&
-          val.transactionId() == utxo.input().transactionId(),
+          val.transactionId() == utxo.input().transactionId()
       )
     ) {
       // If a duplicate is found, throw an error to prevent adding it.
       throw new Error(
-        "Cannot add duplicate reference input to the transaction",
+        "Cannot add duplicate reference input to the transaction"
       );
     }
     // If no duplicate is found, add the input to the array of reference inputs.
@@ -350,7 +350,7 @@ export class TxBuilder {
   addInput(
     utxo: TransactionUnspentOutput,
     redeemer?: PlutusData,
-    unhashDatum?: PlutusData,
+    unhashDatum?: PlutusData
   ): TxBuilder {
     // Retrieve the current inputs from the transaction body for manipulation.
     const inputs = this.body.inputs();
@@ -360,7 +360,7 @@ export class TxBuilder {
       values.find(
         (val) =>
           val.index() == utxo.input().index() &&
-          val.transactionId() == utxo.input().transactionId(),
+          val.transactionId() == utxo.input().transactionId()
       )
     ) {
       throw new Error("Cannot add duplicate input to the transaction");
@@ -392,25 +392,25 @@ export class TxBuilder {
     if (redeemer !== undefined) {
       if (key.type == CredentialType.KeyHash) {
         throw new Error(
-          "addInput: Cannot spend with redeemer for KeyHash credential!",
+          "addInput: Cannot spend with redeemer for KeyHash credential!"
         );
       }
       this.requiredPlutusScripts.add(key.hash);
       const datum = utxo.output().datum();
       if (!datum) {
         throw new Error(
-          "addInput: Cannot spend with redeemer when datum is missing!",
+          "addInput: Cannot spend with redeemer when datum is missing!"
         );
       }
       if (datum?.asInlineData() && unhashDatum) {
         throw new Error(
-          "addInput: Cannot have inline datum and also provided datum (3rd arg).",
+          "addInput: Cannot have inline datum and also provided datum (3rd arg)."
         );
       }
       if (datum?.asDataHash()) {
         if (!unhashDatum) {
           throw new Error(
-            "addInput: When spending datum hash, must provide datum (3rd arg).",
+            "addInput: When spending datum hash, must provide datum (3rd arg)."
           );
         }
         this.plutusData.add(unhashDatum!);
@@ -425,7 +425,7 @@ export class TxBuilder {
             memory: this.params.maxExecutionUnitsPerTransaction.memory,
             steps: this.params.maxExecutionUnitsPerTransaction.steps,
           },
-        }),
+        })
       );
       this.redeemers.setValues(redeemers);
     } else {
@@ -487,11 +487,11 @@ export class TxBuilder {
   addMint(
     policy: PolicyId,
     assets: Map<AssetName, bigint>,
-    redeemer?: PlutusData,
+    redeemer?: PlutusData
   ) {
     const insertIdx = this.insertSorted(
       this.consumedMintHashes,
-      PolicyIdToHash(policy),
+      PolicyIdToHash(policy)
     );
     // Retrieve the current mint map from the transaction body, or initialize a new one if none exists.
     const mint: TokenMap = this.body.mint() ?? new Map();
@@ -533,7 +533,7 @@ export class TxBuilder {
             memory: this.params.maxExecutionUnitsPerTransaction.memory, // Placeholder memory units, replace with actual estimation.
             steps: this.params.maxExecutionUnitsPerTransaction.steps, // Placeholder step units, replace with actual estimation.
           },
-        }),
+        })
       );
       // Update the transaction's redeemers with the new list.
       this.redeemers.setValues(redeemers);
@@ -645,7 +645,7 @@ export class TxBuilder {
         value: { coins: lovelace },
         datum: datumData,
         datumHash,
-      }),
+      })
     );
     return this;
   }
@@ -671,7 +671,7 @@ export class TxBuilder {
         value: value.toCore(),
         datum: datumData,
         datumHash,
-      }),
+      })
     );
     return this;
   }
@@ -692,13 +692,13 @@ export class TxBuilder {
     address: Address,
     lovelace: bigint,
     datum: Datum,
-    scriptReference?: Script,
+    scriptReference?: Script
   ): TxBuilder {
     return this.lockAssets(
       address,
       new Value(lovelace),
       datum,
-      scriptReference,
+      scriptReference
     );
   }
 
@@ -718,7 +718,7 @@ export class TxBuilder {
     address: Address,
     value: Value,
     datum: Datum,
-    scriptReference?: Script,
+    scriptReference?: Script
   ): TxBuilder {
     const datumData = typeof datum == "object" ? datum.toCore() : undefined;
     const datumHash = typeof datum == "string" ? datum : undefined;
@@ -731,13 +731,8 @@ export class TxBuilder {
         datum: datumData,
         datumHash,
         scriptReference: scriptReference?.toCore(),
-      }),
+      })
     );
-  }
-
-  private calculateMinAda(output: TransactionOutput): bigint {
-    const byteLength = BigInt(output.toCbor().length / 2);
-    return BigInt(this.params.coinsPerUtxoByte) * (byteLength + 160n);
   }
 
   /**
@@ -789,7 +784,7 @@ export class TxBuilder {
   private async evaluate(draft_tx: Transaction): Promise<bigint> {
     // Collect all UTXOs from the transaction's scope.
     const allUtxos: TransactionUnspentOutput[] = Array.from(
-      this.utxoScope.values(),
+      this.utxoScope.values()
     );
     // todo: filter utxoscope to only include inputs, reference inputs, collateral inputs, not excess junk
 
@@ -838,7 +833,7 @@ export class TxBuilder {
         const script = scriptLookup[requiredScriptHash];
         if (!script) {
           throw new Error(
-            `complete: Could not resolve script hash ${requiredScriptHash}`,
+            `complete: Could not resolve script hash ${requiredScriptHash}`
           );
         } else {
           if (script.asNative() != undefined) {
@@ -865,7 +860,7 @@ export class TxBuilder {
         this.usedLanguages[PlutusLanguageVersion.V3] = true;
       } else if (!lang) {
         throw new Error(
-          "buildTransactionWitnessSet: lang script lookup failed",
+          "buildTransactionWitnessSet: lang script lookup failed"
         );
       }
     }
@@ -875,14 +870,14 @@ export class TxBuilder {
         const script = scriptLookup[requiredScriptHash];
         if (!script) {
           throw new Error(
-            `complete: Could not resolve script hash ${requiredScriptHash}`,
+            `complete: Could not resolve script hash ${requiredScriptHash}`
           );
         } else {
           if (script.asNative() != undefined) {
             sn.push(script.asNative()!);
           } else {
             throw new Error(
-              "complete: Could not resolve script hash (was not native script)",
+              "complete: Could not resolve script hash (was not native script)"
             );
           }
         }
@@ -917,7 +912,7 @@ export class TxBuilder {
         (_, i) => [
           Ed25519PublicKeyHex(i.toString().padStart(64, "0")),
           Ed25519SignatureHex(i.toString().padStart(128, "0")),
-        ],
+        ]
       );
 
     tw.setVkeys(CborSet.fromCore(requiredWitnesses, VkeyWitness.fromCore));
@@ -988,20 +983,20 @@ export class TxBuilder {
         case 0: // Stake Registration
           outputValue = value.merge(
             outputValue,
-            new Value(BigInt(this.params.stakeKeyDeposit)),
+            new Value(BigInt(this.params.stakeKeyDeposit))
           );
           break;
         case 1: // Stake Deregistration
           inputValue = value.merge(
             inputValue,
-            new Value(BigInt(this.params.stakeKeyDeposit)),
+            new Value(BigInt(this.params.stakeKeyDeposit))
           );
           break;
         case 3: // Pool Registration
           if (this.params.poolDeposit) {
             outputValue = value.merge(
               outputValue,
-              new Value(BigInt(this.params.poolDeposit)),
+              new Value(BigInt(this.params.poolDeposit))
             );
           }
           break;
@@ -1009,7 +1004,7 @@ export class TxBuilder {
           if (this.params.poolDeposit) {
             inputValue = value.merge(
               inputValue,
-              new Value(BigInt(this.params.poolDeposit)),
+              new Value(BigInt(this.params.poolDeposit))
             );
           }
           break;
@@ -1020,14 +1015,14 @@ export class TxBuilder {
     // Subtract a fixed fee amount (5 ADA) to ensure enough is allocated for transaction fees.
     const tilt = value.merge(
       value.merge(inputValue, value.negate(outputValue)),
-      mintValue,
+      mintValue
     );
     if (spareAmount != 0n) {
       return value.merge(tilt, new Value(-spareAmount)); // Subtract 5 ADA from the excess.
     }
     return value.merge(
       tilt,
-      this.body.outputs()[this.changeOutputIndex!]!.amount(),
+      this.body.outputs()[this.changeOutputIndex!]!.amount()
     );
   }
 
@@ -1072,20 +1067,20 @@ export class TxBuilder {
         case 0: // Stake Registration
           outputValue = value.merge(
             outputValue,
-            new Value(BigInt(this.params.stakeKeyDeposit)),
+            new Value(BigInt(this.params.stakeKeyDeposit))
           );
           break;
         case 1: // Stake Deregistration
           inputValue = value.merge(
             inputValue,
-            new Value(BigInt(this.params.stakeKeyDeposit)),
+            new Value(BigInt(this.params.stakeKeyDeposit))
           );
           break;
         case 3: // Pool Registration
           if (this.params.poolDeposit) {
             outputValue = value.merge(
               outputValue,
-              new Value(BigInt(this.params.poolDeposit)),
+              new Value(BigInt(this.params.poolDeposit))
             );
           }
           break;
@@ -1093,7 +1088,7 @@ export class TxBuilder {
           if (this.params.poolDeposit) {
             inputValue = value.merge(
               inputValue,
-              new Value(BigInt(this.params.poolDeposit)),
+              new Value(BigInt(this.params.poolDeposit))
             );
           }
           break;
@@ -1101,7 +1096,7 @@ export class TxBuilder {
     }
     const tilt = value.merge(
       value.merge(inputValue, value.negate(outputValue)),
-      mintValue,
+      mintValue
     );
     return tilt.toCbor() == value.zero().toCbor();
   }
@@ -1114,7 +1109,7 @@ export class TxBuilder {
    * @returns {Hash32ByteBase16 | undefined} The script data hash if datums or redeemers are present, otherwise undefined.
    */
   private getScriptDataHash(
-    tw: TransactionWitnessSet,
+    tw: TransactionWitnessSet
   ): Hash32ByteBase16 | undefined {
     // Extract redeemers and datums from the transaction witness set.
     const redeemers = [...this.redeemers.values()];
@@ -1154,7 +1149,7 @@ export class TxBuilder {
           // Throw an error if the cost model is missing.
           if (cm == undefined) {
             throw new Error(
-              `complete: Could not find cost model for Plutus Language Version ${i}`,
+              `complete: Could not find cost model for Plutus Language Version ${i}`
             );
           }
           // Insert the cost model into the used cost models container.
@@ -1163,7 +1158,7 @@ export class TxBuilder {
       }
       // Encode the used cost models into CBOR format.
       writer.writeEncodedValue(
-        Buffer.from(usedCostModels.languageViewsEncoding(), "hex"),
+        Buffer.from(usedCostModels.languageViewsEncoding(), "hex")
       );
       // Generate and return the script data hash.
       return blake2b_256(writer.encodeAsHex());
@@ -1231,7 +1226,7 @@ export class TxBuilder {
           utxoScope
             .find((y) => y.input().toCbor() == x.toCbor())!
             .output()
-            .scriptRef(),
+            .scriptRef()
         )
         .filter((x) => x !== undefined);
       if (refScripts.length > 0) {
@@ -1252,7 +1247,7 @@ export class TxBuilder {
     // Retrieve provided collateral inputs
     const providedCollateral = [...this.collateralUtxos.values()].sort(
       (a, b) =>
-        a.output().amount().coin() < b.output().amount().coin() ? -1 : 1,
+        a.output().amount().coin() < b.output().amount().coin() ? -1 : 1
     );
     // Retrieve inputs from the transaction body and available UTXOs within scope.
     const inputs = [...this.body.inputs().values()];
@@ -1289,7 +1284,7 @@ export class TxBuilder {
         const utxo = scope.find(
           (x) =>
             x.input().transactionId() === input.transactionId() &&
-            x.input().index() === input.index(),
+            x.input().index() === input.index()
         );
 
         if (utxo) {
@@ -1357,7 +1352,7 @@ export class TxBuilder {
         if (adaAmount < 5_000_000n) {
           // create a sorted list of utxos by ada amount
           const adaUtxos = [...this.utxos.values()].sort((a, b) =>
-            a.output().amount().coin() < b.output().amount().coin() ? -1 : 1,
+            a.output().amount().coin() < b.output().amount().coin() ? -1 : 1
           );
           for (
             let i = 0;
@@ -1373,7 +1368,7 @@ export class TxBuilder {
         }
         if (adaAmount <= 5_000_000) {
           throw new Error(
-            "prepareCollateral: could not find enough collateral (5 ada minimum)",
+            "prepareCollateral: could not find enough collateral (5 ada minimum)"
           );
         }
         best = collateral;
@@ -1397,8 +1392,8 @@ export class TxBuilder {
       this.collateralChangeAddress ?? this.changeAddress!,
       best.reduce(
         (acc, x) => value.merge(acc, x.output().amount()),
-        value.zero(),
-      ),
+        value.zero()
+      )
     );
     this.body.setCollateralReturn(ret);
   }
@@ -1430,7 +1425,7 @@ export class TxBuilder {
     for (const [asset, qty] of Array.from(multiAsset.entries())) {
       const newOutputValue = value.merge(
         output.amount(),
-        value.makeValue(0n, [asset, qty]),
+        value.makeValue(0n, [asset, qty])
       );
       const newOutputValueByteLength = newOutputValue.toCbor().length / 2;
       //We need to check if the new output value is too large
@@ -1440,7 +1435,7 @@ export class TxBuilder {
         changeExcess = value.sub(changeExcess, output.amount());
         output = new TransactionOutput(
           this.changeAddress!,
-          value.makeValue(0n, [asset, qty]),
+          value.makeValue(0n, [asset, qty])
         );
       } else {
         output = new TransactionOutput(this.changeAddress!, newOutputValue);
@@ -1473,8 +1468,8 @@ export class TxBuilder {
     const totalCollateral = BigInt(
       Math.ceil(
         (this.params.collateralPercentage / 100) *
-          Number(bigintMax(this.fee, this.minimumFee) + this.feePadding),
-      ),
+          Number(bigintMax(this.fee, this.minimumFee) + this.feePadding)
+      )
     );
     // Calculate the collateral value by summing up the amounts from collateral inputs.
     const collateralValue = this.body
@@ -1484,11 +1479,11 @@ export class TxBuilder {
         const utxo = scope.find(
           (x) =>
             x.input().transactionId() === input.transactionId() &&
-            x.input().index() === input.index(),
+            x.input().index() === input.index()
         );
         if (!utxo) {
           throw new Error(
-            "balanceCollateralChange: Could not resolve some collateral input",
+            "balanceCollateralChange: Could not resolve some collateral input"
           );
         }
         return value.merge(utxo.output().amount(), acc);
@@ -1497,8 +1492,8 @@ export class TxBuilder {
     this.body.setCollateralReturn(
       new TransactionOutput(
         this.changeAddress,
-        value.merge(collateralValue, new Value(-totalCollateral)),
-      ),
+        value.merge(collateralValue, new Value(-totalCollateral))
+      )
     );
     // Update the transaction body with the total collateral amount.
     this.body.setTotalCollateral(totalCollateral);
@@ -1537,12 +1532,12 @@ export class TxBuilder {
     // Ensure a change address has been set before proceeding.
     if (!this.changeAddress) {
       throw new Error(
-        "Cannot complete transaction without setting change address",
+        "Cannot complete transaction without setting change address"
       );
     }
     if (this.networkId === undefined) {
       throw new Error(
-        "Cannot complete transaction without setting a network id",
+        "Cannot complete transaction without setting a network id"
       );
     }
     // TODO: Potential bug with js SDK where setting the network to testnet causes the tx body CBOR to fail
@@ -1553,14 +1548,14 @@ export class TxBuilder {
     // Perform initial checks and preparations for coin selection.
     const preliminaryDraftTx = new Transaction(
       this.body,
-      new TransactionWitnessSet(),
+      new TransactionWitnessSet()
     );
     const preliminaryFee =
       this.params.minFeeConstant +
       fromHex(preliminaryDraftTx.toCbor()).length *
         this.params.minFeeCoefficient;
     let excessValue = this.getPitch(
-      bigintMax(BigInt(Math.ceil(preliminaryFee)), this.minimumFee),
+      bigintMax(BigInt(Math.ceil(preliminaryFee)), this.minimumFee)
     );
     let spareInputs: TransactionUnspentOutput[] = [];
     for (const [utxo] of this.utxos.entries()) {
@@ -1571,7 +1566,7 @@ export class TxBuilder {
     // Perform coin selection to cover any negative excess value.
     const selectionResult = this.coinSelector(
       spareInputs,
-      value.negate(value.negatives(excessValue)),
+      value.negate(value.negatives(excessValue))
     );
     // Update the excess value and spare inputs based on the selection result.
     excessValue = value.merge(excessValue, selectionResult.selectedValue);
@@ -1585,37 +1580,37 @@ export class TxBuilder {
       if (this.body.inputs().size() == 0) {
         if (!spareInputs[0]) {
           throw new Error(
-            "No spare inputs available to add to the transaction",
+            "No spare inputs available to add to the transaction"
           );
         }
         // Select the input with the least number of different multiassets from spareInputs
         const [inputWithLeastMultiAssets] = spareInputs.reduce(
           ([minInput, minMultiAssetCount], currentInput) => {
             const currentMultiAssetCount = value.assetTypes(
-              currentInput.output().amount(),
+              currentInput.output().amount()
             );
             return currentMultiAssetCount < minMultiAssetCount
               ? [currentInput, minMultiAssetCount]
               : [minInput, value.assetTypes(minInput.output().amount())];
           },
-          [spareInputs[0], value.assetTypes(spareInputs[0].output().amount())],
+          [spareInputs[0], value.assetTypes(spareInputs[0].output().amount())]
         );
         this.addInput(inputWithLeastMultiAssets);
         // Remove the selected input from spareInputs
         spareInputs = spareInputs.filter(
-          (input) => input !== inputWithLeastMultiAssets,
+          (input) => input !== inputWithLeastMultiAssets
         );
       }
     }
     if (this.body.inputs().values().length == 0) {
       throw new Error(
-        "TxBuilder: resolved empty input set, cannot construct transaction!",
+        "TxBuilder: resolved empty input set, cannot construct transaction!"
       );
     }
     // Ensure the coin selection has eliminated all negative values.
     if (!value.empty(value.negatives(excessValue))) {
       throw new Error(
-        "Unreachable! Somehow coin selection succeeded but still failed.",
+        "Unreachable! Somehow coin selection succeeded but still failed."
       );
     }
 
@@ -1626,7 +1621,7 @@ export class TxBuilder {
     // Ensure a change output index has been set after balancing.
     if (this.changeOutputIndex === undefined) {
       throw new Error(
-        "Unreachable! Somehow change balancing succeeded but still failed.",
+        "Unreachable! Somehow change balancing succeeded but still failed."
       );
     }
     // Build the transaction witness set for fee estimation and script validation.
@@ -1645,13 +1640,13 @@ export class TxBuilder {
       const auxiliaryDataHash = this.getAuxiliaryDataHash(auxiliaryData);
       if (auxiliaryDataHash != this.body.auxiliaryDataHash()) {
         throw new Error(
-          "TxBuilder complete: auxiliary data somehow didn't match auxiliary data hash",
+          "TxBuilder complete: auxiliary data somehow didn't match auxiliary data hash"
         );
       }
     } else {
       if (this.body.auxiliaryDataHash() != undefined) {
         throw new Error(
-          "TxBuilder complete: auxiliary data somehow didn't match auxiliary data hash",
+          "TxBuilder complete: auxiliary data somehow didn't match auxiliary data hash"
         );
       }
     }
@@ -1665,8 +1660,8 @@ export class TxBuilder {
       excessValue,
       new Value(
         -(bigintMax(this.fee, this.minimumFee) + this.feePadding) +
-          BigInt(preliminaryFee),
-      ),
+          BigInt(preliminaryFee)
+      )
     );
     this.balanceChange(excessValue);
     let evaluationFee: bigint = 0n;
@@ -1677,7 +1672,7 @@ export class TxBuilder {
         evaluationFee = await this.evaluate(draft_tx);
       } catch (e) {
         console.log(
-          `An error occurred when trying to evaluate this transaction. Full CBOR: ${draft_tx.toCbor()}`,
+          `An error occurred when trying to evaluate this transaction. Full CBOR: ${draft_tx.toCbor()}`
         );
         throw e;
       }
@@ -1703,14 +1698,14 @@ export class TxBuilder {
     }
     if (this.feePadding > 0n) {
       console.warn(
-        "A transaction was built using fee padding. This is useful for working around changes to fee calculation, but ultimately is a bandaid. If you find yourself needing this, please open a ticket at https://github.com/butaneprotocol/blaze-cardano so we can fix the underlying inaccuracy!",
+        "A transaction was built using fee padding. This is useful for working around changes to fee calculation, but ultimately is a bandaid. If you find yourself needing this, please open a ticket at https://github.com/butaneprotocol/blaze-cardano so we can fix the underlying inaccuracy!"
       );
     }
     let final_size = draft_size;
     do {
       const oldEvaluationFee = evaluationFee;
       this.fee += BigInt(
-        Math.ceil((final_size - draft_size) * this.params.minFeeCoefficient),
+        Math.ceil((final_size - draft_size) * this.params.minFeeCoefficient)
       );
       excessValue = this.getPitch();
 
@@ -1720,7 +1715,7 @@ export class TxBuilder {
       if (changeOutput.amount().coin() > excessValue.coin()) {
         const excessDifference = value.merge(
           changeOutput!.amount(),
-          value.negate(excessValue),
+          value.negate(excessValue)
         );
         // we must add more inputs, to cover the difference
         if (spareInputs.length == 0) {
@@ -1728,7 +1723,7 @@ export class TxBuilder {
         }
         const selectionResult = this.coinSelector(
           spareInputs,
-          excessDifference,
+          excessDifference
         );
         spareInputs = selectionResult.inputs;
         for (const input of selectionResult.selectedInputs) {
@@ -1774,7 +1769,7 @@ export class TxBuilder {
   addDelegation(
     delegator: Credential,
     poolId: PoolId,
-    redeemer?: PlutusData,
+    redeemer?: PlutusData
   ): TxBuilder {
     const stakeDelegation: StakeDelegationCertificate = {
       __typename: CertificateType.StakeDelegation,
@@ -1782,7 +1777,7 @@ export class TxBuilder {
       poolId: poolId,
     };
     const delegationCertificate: Certificate = Certificate.newStakeDelegation(
-      StakeDelegation.fromCore(stakeDelegation),
+      StakeDelegation.fromCore(stakeDelegation)
     );
     const certs =
       this.body.certs() ?? CborSet.fromCore([], Certificate.fromCore);
@@ -1803,7 +1798,7 @@ export class TxBuilder {
               memory: this.params.maxExecutionUnitsPerTransaction.memory,
               steps: this.params.maxExecutionUnitsPerTransaction.steps,
             },
-          }),
+          })
         );
         this.redeemers.setValues(redeemers);
       } else {
@@ -1811,7 +1806,7 @@ export class TxBuilder {
       }
     } else if (redeemer) {
       throw new Error(
-        "TxBuilder addDelegation: failing to attach redeemer to a non-script delegation!",
+        "TxBuilder addDelegation: failing to attach redeemer to a non-script delegation!"
       );
     } else {
       this.requiredWitnesses.add(HashAsPubKeyHex(delegatorCredential.hash));
@@ -1834,7 +1829,7 @@ export class TxBuilder {
     const credential = this.rewardAddress!.getProps().delegationPart;
     if (!credential) {
       throw new Error(
-        "TxBuilder delegate: Somehow the reward address had no stake component",
+        "TxBuilder delegate: Somehow the reward address had no stake component"
       );
     }
     this.addDelegation(Credential.fromCore(credential), poolId, redeemer);
@@ -1848,7 +1843,7 @@ export class TxBuilder {
    */
   addRegisterStake(credential: Credential) {
     const stakeRegistration: StakeRegistration = new StakeRegistration(
-      credential.toCore(),
+      credential.toCore()
     );
     const registrationCertificate: Certificate =
       Certificate.newStakeRegistration(stakeRegistration);
@@ -1894,7 +1889,7 @@ export class TxBuilder {
   setValidFrom(validFrom: Slot): TxBuilder {
     if (this.body.validityStartInterval() !== undefined) {
       throw new Error(
-        "TxBuilder setValidFrom: Validity start interval is already set",
+        "TxBuilder setValidFrom: Validity start interval is already set"
       );
     }
     this.body.setValidityStartInterval(validFrom);
@@ -1929,18 +1924,18 @@ export class TxBuilder {
   addWithdrawal(
     address: RewardAccount,
     amount: bigint,
-    redeemer?: PlutusData,
+    redeemer?: PlutusData
   ): TxBuilder {
     const withdrawalHash =
       Address.fromBech32(address).getProps().paymentPart?.hash;
     if (!withdrawalHash) {
       throw new Error(
-        "addWithdrawal: The RewardAccount provided does not have an associated stake credential.",
+        "addWithdrawal: The RewardAccount provided does not have an associated stake credential."
       );
     }
     const insertIdx = this.insertSorted(
       this.consumedWithdrawalHashes,
-      withdrawalHash,
+      withdrawalHash
     );
     // Retrieve existing withdrawals or initialize a new map if none exist.
     const withdrawals: Map<RewardAccount, bigint> =
@@ -1948,7 +1943,7 @@ export class TxBuilder {
     // Sanity check duplicates
     if (withdrawals.has(address)) {
       throw new Error(
-        "addWithdrawal: Withdrawal for this address already exists.",
+        "addWithdrawal: Withdrawal for this address already exists."
       );
     }
     // Set the withdrawal amount for the specified address.
@@ -1977,7 +1972,7 @@ export class TxBuilder {
             memory: this.params.maxExecutionUnitsPerTransaction.memory,
             steps: this.params.maxExecutionUnitsPerTransaction.steps,
           },
-        }),
+        })
       );
       // Update the transaction with the new list of redeemers.
       this.redeemers.setValues(redeemers);
@@ -1986,7 +1981,7 @@ export class TxBuilder {
       const key = Address.fromBech32(address).getProps().paymentPart;
       if (!key) {
         throw new Error(
-          "addWithdrawal: The RewardAccount provided does not have an associated stake credential.",
+          "addWithdrawal: The RewardAccount provided does not have an associated stake credential."
         );
       }
       // Add the required scripts or witnesses based on the type of the stake credential.
@@ -2027,7 +2022,7 @@ export class TxBuilder {
    * @returns {Hash32ByteBase16 | undefined} The hash of the auxiliary data or undefined if no auxiliary data is provided.
    */
   private getAuxiliaryDataHash(
-    auxiliaryData: AuxiliaryData,
+    auxiliaryData: AuxiliaryData
   ): Hash32ByteBase16 | undefined {
     return auxiliaryData ? blake2b_256(auxiliaryData.toCbor()) : undefined;
   }
@@ -2093,7 +2088,7 @@ function assertPaymentsAddress(address: Address) {
   }
   if (props.paymentPart.type == CredentialType.ScriptHash) {
     throw new Error(
-      "assertPaymentsAddress: address payment credential cannot be a script hash!",
+      "assertPaymentsAddress: address payment credential cannot be a script hash!"
     );
   }
 }
@@ -2110,7 +2105,7 @@ function assertLockAddress(address: Address) {
   }
   if (props.paymentPart.type != CredentialType.ScriptHash) {
     throw new Error(
-      "assertLockAddress: address payment credential must be a script hash!",
+      "assertLockAddress: address payment credential must be a script hash!"
     );
   }
 }

--- a/sites/docs/next-env.d.ts
+++ b/sites/docs/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.


### PR DESCRIPTION
- Method to lock a UTXO at a burn address with minimum ADA and a provided script as a script ref
- Provider query to resolve a script to it's deployment utxo (for using as a reference input)

This can also open up the discussion as to how this feature should function and should be extended moving forward.

Note that this is part of one of the F12 Catalyst proposals for Blaze https://www.lidonation.com/en/proposals/blaze-tools-for-handling-and-managing-script-deployments-f12