### PR TITLE
Support Zero Fee Transactions

### DIFF
--- a/.changeset/polite-carrots-smash.md
+++ b/.changeset/polite-carrots-smash.md
@@ -1,0 +1,5 @@
+---
+"@blaze-cardano/tx": patch
+---
+
+support zero fee transactions

--- a/packages/blaze-tx/src/tx.ts
+++ b/packages/blaze-tx/src/tx.ts
@@ -1025,10 +1025,14 @@ export class TxBuilder {
     if (spareAmount != 0n) {
       return value.merge(tilt, new Value(-spareAmount)); // Subtract 5 ADA from the excess.
     }
-    return value.merge(
-      tilt,
-      this.body.outputs()[this.changeOutputIndex!]!.amount(),
-    );
+    if (this.changeOutputIndex !== undefined) {
+      return value.merge(
+        tilt,
+        this.body.outputs()[this.changeOutputIndex]!.amount(),
+      );
+    }
+
+    return tilt;
   }
 
   private balanced() {


### PR DESCRIPTION
In a Hydra head, (and other contexts, but hydra is the most realistic) transactions can have a fee of `0`. A transaction with a fee of zero will cause issues with the current transaction balancing. This PR gracefully handles zero fee transactions.