### PR TITLE
Fix PlutusV3 cost model encoding in Blockfrost

### DIFF
--- a/.changeset/shaggy-turkeys-end.md
+++ b/.changeset/shaggy-turkeys-end.md
@@ -1,0 +1,5 @@
+---
+"@blaze-cardano/query": patch
+---
+
+fix cost model encoding for plutusv3

--- a/packages/blaze-query/src/blockfrost.ts
+++ b/packages/blaze-query/src/blockfrost.ts
@@ -83,15 +83,11 @@ export class Blockfrost extends Provider {
     }
     // Build cost models
     const costModels: CostModels = new Map();
-    for (const cm of Object.keys(
-      response.cost_models,
-    ) as BlockfrostLanguageVersions[]) {
-      const costModel: number[] = [];
-      const keys = Object.keys(response.cost_models[cm]).sort();
-      for (const key of keys) {
-        costModel.push(response.cost_models[cm][key]!);
-      }
-      costModels.set(fromBlockfrostLanguageVersion(cm), costModel);
+    for (const [key, value] of Object.entries(response.cost_models_raw)) {
+      costModels.set(
+        fromBlockfrostLanguageVersion(key as BlockfrostLanguageVersions),
+        value,
+      );
     }
 
     return {
@@ -737,6 +733,7 @@ export interface BlockfrostProtocolParametersResponse {
   min_pool_cost: number;
   nonce: string;
   cost_models: Record<BlockfrostLanguageVersions, { [key: string]: number }>;
+  cost_models_raw: Record<BlockfrostLanguageVersions, number[]>;
   price_mem: string;
   price_step: string;
   max_tx_ex_mem: number;


### PR DESCRIPTION
There were new cost models added to PlutusV3 that do not follow the ordering convention of alphabetical key ordering. Therefore, the sort moves values to places where they are not in the latest protocol parameter update transaction. Fortunately, blockfrost returns a `cost_models_raw` which is already in the ordering that exists on the ledger.