### PR TITLE
Error Handling Fix

### DIFF
--- a/.changeset/poor-sheep-fetch.md
+++ b/.changeset/poor-sheep-fetch.md
@@ -1,0 +1,5 @@
+---
+"@blaze-cardano/tx": patch
+---
+
+Error handling improvements for missing redeemers.

--- a/packages/blaze-tx/src/tx.ts
+++ b/packages/blaze-tx/src/tx.ts
@@ -882,7 +882,7 @@ export class TxBuilder {
             sn.push(script.asNative()!);
           } else {
             throw new Error(
-              `complete: Could not resolve script hash: ${script.hash()} (was not native script). Did you forget to add a redeemer?`,
+              `complete: Could not resolve script hash: ${script.hash()} (was not native script). Did you forget to add a redeemer, attach a reference input, or call provideScript?`,
             );
           }
         }

--- a/packages/blaze-tx/src/tx.ts
+++ b/packages/blaze-tx/src/tx.ts
@@ -882,7 +882,7 @@ export class TxBuilder {
             sn.push(script.asNative()!);
           } else {
             throw new Error(
-              "complete: Could not resolve script hash (was not native script)",
+              `complete: Could not resolve script hash: ${script.hash()} (was not native script). Did you forget to add a redeemer?`,
             );
           }
         }


### PR DESCRIPTION
If a user forgets to add a redeemer to an input, the `buildTransactionWitnessSet` method will just assume it's suppose to be a native script. This adds better error handling by:

- Including the script hash in the error message.
- Reminding the user to check if they missed a redeemer.