### PR TITLE
fix: outdated actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
   pages: write
   id-token: write
@@ -20,7 +21,7 @@ jobs:
       - run: pnpm i
       - run: pnpm run build
       - run: pnpm run docs
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: ./docs
   deploy:
@@ -32,4 +33,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
The deploy pipeline is broken for building docs due to [this issue](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/), where `actions/upload-pages-artifact@v2` has been deprecated and requires v3 in order to run.