### PR TITLE
Emulator "multisignature" helper

### DIFF
--- a/.changeset/rude-islands-bathe.md
+++ b/.changeset/rude-islands-bathe.md
@@ -1,0 +1,5 @@
+---
+"@blaze-cardano/emulator": patch
+---
+
+Add a new helper to the emulator for testing multi-signed transactions


### PR DESCRIPTION
This adds a helper for testing valid multisigned transactions, since htat was pretty awkward.

Usable like this:
```ts
        const tx = await emulator.as(Funder, async (blaze) => {
          return fund(
            configs,
            blaze,
            fourthScriptInput,
            vendor,
            [
              {
                date: new Date(Number(slot_to_unix(Slot(10)))),
                amount: makeValue(25_000_000n),
              },
              {
                date: new Date(Number(slot_to_unix(Slot(12)))),
                amount: makeValue(25_000_000n, ["b".repeat(56), 50n]),
              },
            ],
            [
              Ed25519KeyHashHex(await fund_key(emulator)),
              Ed25519KeyHashHex(await vendor_key(emulator)),
            ],
          );
        });
        await emulator.expectValidMultisignedTransaction([Funder, Vendor], tx);
```