### PR TITLE
move optional check above ref check

### DIFF
--- a/packages/blaze-data/src/index.ts
+++ b/packages/blaze-data/src/index.ts
@@ -80,6 +80,19 @@ export function _serialize<T extends TSchema>(
     );
   }
 
+  if (isOptional(type)) {
+    if (data !== null && data !== undefined) {
+      const innerType = Type.Optional(type, false);
+      const fields = new PlutusList();
+      fields.add(_serialize(innerType, data as any, path, defs));
+      return PlutusData.newConstrPlutusData(new ConstrPlutusData(0n, fields));
+    } else {
+      return PlutusData.newConstrPlutusData(
+        new ConstrPlutusData(1n, new PlutusList()),
+      );
+    }
+  }
+
   if (data instanceof PlutusData) {
     return data;
   }
@@ -99,19 +112,6 @@ export function _serialize<T extends TSchema>(
       );
     }
     return _serialize(resolvedType, data, path, defs);
-  }
-
-  if (isOptional(type)) {
-    if (data !== null && data !== undefined) {
-      const innerType = Type.Optional(type, false);
-      const fields = new PlutusList();
-      fields.add(_serialize(innerType, data as any, path, defs));
-      return PlutusData.newConstrPlutusData(new ConstrPlutusData(0n, fields));
-    } else {
-      return PlutusData.newConstrPlutusData(
-        new ConstrPlutusData(1n, new PlutusList()),
-      );
-    }
   }
 
   if (isUnion(type)) {

--- a/packages/blaze-data/test/index.test.ts
+++ b/packages/blaze-data/test/index.test.ts
@@ -206,6 +206,23 @@ describe("serialize", () => {
     const out2 = serialize(schema, inp2, defs);
     expect(out2.toCbor()).toEqual(newConstr(1n, []).toCbor());
   });
+
+it("should be able to serialize with optional type references", () => {
+    const defs = {
+      T0: Type.Literal("Something", { ctor: 0 }),
+    };
+    const schema = Type.Object({
+      MyOption: Type.Optional(Type.Ref("T0"))
+    }, { ctor: 0 });
+
+    const inp1 = { MyOption: "Something" };
+    const out1 = serialize(schema, inp1, defs);
+    expect(out1.toCbor()).toEqual(newConstr(0n, [newConstr(0n, [newConstr(0n, [])])]).toCbor());
+
+    const inp2 = { MyOption: undefined };
+    const out2 = serialize(schema, inp2, defs);
+    expect(out2.toCbor()).toEqual(newConstr(0n, [newConstr(1n, [])]).toCbor());
+  });
 });
 
 describe("parse", () => {


### PR DESCRIPTION
Optionals wrapped around a Ref type result in the _serialize function going down the ref branch before it has a chance to check that the type is optional or not. This PR fixes that.