### PR TITLE
Fix (data): Optional type references parsed correctly

### DIFF
--- a/.changeset/slimy-points-bathe.md
+++ b/.changeset/slimy-points-bathe.md
@@ -1,0 +1,5 @@
+---
+"@blaze-cardano/data": patch
+---
+
+fix: Optional type references parsed correctly

--- a/packages/blaze-data/src/index.ts
+++ b/packages/blaze-data/src/index.ts
@@ -574,11 +574,14 @@ function resolveType<T extends TSchema>(
 ): T {
   if (isRef(type) || isThis(type) || isImport(type)) {
     defs = { ...defs, ...type.$defs };
-    const realType = defs[type.$ref];
+    let realType = defs[type.$ref];
     if (!realType) {
       throw new Error(
         `Invalid type at ${path.join(".")}: Unrecognized reference ${type.$ref}`,
       );
+    }
+    if (isOptional(type)) {
+      realType = Type.Optional(realType, true);
     }
     return resolveType(realType, path, defs) as T;
   }

--- a/packages/blaze-data/test/index.test.ts
+++ b/packages/blaze-data/test/index.test.ts
@@ -427,6 +427,41 @@ describe("parse", () => {
     const out2 = parse(schema, inp2, defs);
     expect(out2).toEqual("Other");
   });
+
+  it("should be able to parse optional type references", () => {
+    const defs = {
+      T0: Type.String(),
+    };
+    const schema = Type.Object(
+      {
+        required: Type.BigInt(),
+        optional: Type.Optional(Type.Ref("T0")),
+      },
+      { ctor: 0 },
+    );
+
+    const inp1 = newConstr(0n, [
+      newInteger(1337n),
+      newConstr(0n, [newBytes("4242")]),
+    ]);
+    const out1 = parse(schema, inp1, defs);
+    expect(out1).toEqual({
+      required: 1337n,
+      optional: "4242",
+    });
+
+    const inp2 = newConstr(0n, [newInteger(1337n), newConstr(1n, [])]);
+    const out2 = parse(schema, inp2, defs);
+    expect(out2).toEqual({
+      required: 1337n,
+    });
+
+    const inp3 = newConstr(0n, [newInteger(1337n)]);
+    const out3 = parse(schema, inp3, defs);
+    expect(out3).toEqual({
+      required: 1337n,
+    });
+  });
 });
 
 // factories to make tests less obnoxious


### PR DESCRIPTION
There was a bug where having an optional reference type wouldn't be parsed correctly, as when resolving the type the optional property would be ignored.