### PR TITLE
Set the collateral in the case that the provided collateral *is* enough!

### DIFF
--- a/packages/blaze-tx/src/TxBuilder.ts
+++ b/packages/blaze-tx/src/TxBuilder.ts
@@ -1623,6 +1623,12 @@ export class TxBuilder {
 
         this.collateralUtxos = new Set(selectedInputs);
         this.body.setCollateral(collateralSet);
+      } else {
+        const collateralSet = CborSet.fromCore([], TransactionInput.fromCore);
+        collateralSet.setValues(
+          [...this.collateralUtxos.values()].map((c) => c.input()),
+        );
+        this.body.setCollateral(collateralSet);
       }
 
       const collateralOutput = new TransactionOutput(


### PR DESCRIPTION
Normally, we do UTxO selection to pick the collateral UTxOs;

If we provide the collateral explicitly though, we never actually called body.setCollateral!

We've never noticed that before, because usually when we're providing collateral explicitly, we're also skipping coin selection!