### PR TITLE
fix: Skip language checking for native scripts in TxBuilder

### DIFF
--- a/packages/blaze-tx/src/TxBuilder.ts
+++ b/packages/blaze-tx/src/TxBuilder.ts
@@ -901,17 +901,21 @@ export class TxBuilder {
         }
       }
       // Mark the script language versions used in the transaction
-      const lang = scriptLookup[requiredScriptHash]?.language();
-      if (lang == 1) {
-        this.usedLanguages[PlutusLanguageVersion.V1] = true;
-      } else if (lang == 2) {
-        this.usedLanguages[PlutusLanguageVersion.V2] = true;
-      } else if (lang == 3) {
-        this.usedLanguages[PlutusLanguageVersion.V3] = true;
-      } else if (!lang) {
-        throw new Error(
-          "buildTransactionWitnessSet: lang script lookup failed",
-        );
+      // Skip language checking for native scripts
+      const script = scriptLookup[requiredScriptHash];
+      if (script?.asNative() == undefined) {
+        const lang = script?.language();
+        if (lang == 1) {
+          this.usedLanguages[PlutusLanguageVersion.V1] = true;
+        } else if (lang == 2) {
+          this.usedLanguages[PlutusLanguageVersion.V2] = true;
+        } else if (lang == 3) {
+          this.usedLanguages[PlutusLanguageVersion.V3] = true;
+        } else if (!lang) {
+          throw new Error(
+            "buildTransactionWitnessSet: lang script lookup failed",
+          );
+        }
       }
     }
     // do native script check too


### PR DESCRIPTION
## Problem

Native scripts provided via `provideScript()` were causing transaction building to fail with the error:
```
UTxOSelectionError: UTxO Balance Insufficient
buildTransactionWitnessSet: lang script lookup failed
```

This occurred because native scripts were being processed through Plutus language version detection, which fails since native scripts don't have language versions.

## Root Cause

In `TxBuilder.ts`, the witness building process attempts to detect language versions for all scripts in `requiredPlutusScripts`. However, native scripts that end up in this collection (via `provideScript()` or misclassification) would fail the language check since `script.language()` returns undefined for native scripts.

## Solution

Added a condition to skip language version detection for native scripts:
- Check `if (script?.asNative() == undefined)` before running language detection
- Native scripts are still properly handled by the existing script categorization logic
- Plutus scripts continue to work exactly as before

## Testing

This fix resolves cases where:
- UTxOs locked by native scripts couldn't be spent 
- Transactions using `provideScript()` with native scripts would fail
- Mixed native/Plutus script transactions would error during completion

## Impact

- ✅ Minimal change - only wraps existing language detection in a condition
- ✅ Backward compatible - no changes to Plutus script handling  
- ✅ Preserves all existing functionality
- ✅ Fixes critical issue preventing native script usage