### PR TITLE
Include UPLC WASM Files in Published Package

### DIFF
--- a/.changeset/eight-berries-tell.md
+++ b/.changeset/eight-berries-tell.md
@@ -1,0 +1,6 @@
+---
+"@blaze-cardano/uplc": patch
+"@blaze-cardano/vm": patch
+---
+
+Updates the wasm pack script to remove default .gitignore file from packages. This was preventing them from being included in published files.

--- a/packages/blaze-uplc/wasm/build.sh
+++ b/packages/blaze-uplc/wasm/build.sh
@@ -2,13 +2,16 @@ rm -rf pkg ../dist/wasm ../dist/wasm/pkg-node ../dist/wasm/pkg-web ../dist/wasm/
 mkdir ../dist/wasm
 
 wasm-pack build --target nodejs
+rm pkg/.gitignore
 jq '.name = "uplc-node"' pkg/package.json > pkgtemp.json && mv pkgtemp.json pkg/package.json
 mv pkg ../dist/wasm/pkg-node
 
 wasm-pack build --target web
+rm pkg/.gitignore
 jq '.name = "uplc-web"' pkg/package.json > pkgtemp.json && mv pkgtemp.json pkg/package.json
 mv pkg ../dist/wasm/pkg-web
 
 wasm-pack build --target bundler
+rm pkg/.gitignore
 jq '.name = "uplc-bundler"' pkg/package.json > pkgtemp.json && mv pkgtemp.json pkg/package.json
 mv pkg ../dist/wasm/pkg-bundler


### PR DESCRIPTION
Updates the wasm pack script to remove default .gitignore file from packages. This was preventing them from being included in published files.