### PR TITLE
fix(wallet): auto-detect stake key signing from requiredSigners

### DIFF
--- a/.changeset/hot-wallet-auto-stake-sign.md
+++ b/.changeset/hot-wallet-auto-stake-sign.md
@@ -1,0 +1,7 @@
+---
+"@blaze-cardano/wallet": patch
+---
+
+Auto-detect stake key signing in HotWallet from requiredSigners
+
+HotWallet.signTransaction() now inspects tx.body().requiredSigners() for the wallet's stake key hash and automatically signs with the stake key when present. This mirrors CIP-30 wallet behavior where all required keys are signed automatically, fixing test failures when the SDK sets the owner credential to the stake key hash.

--- a/packages/blaze-wallet/src/hot.ts
+++ b/packages/blaze-wallet/src/hot.ts
@@ -245,6 +245,20 @@ export class HotWallet implements Wallet {
 
     const vkeys = [payemntVkw.toCore()];
 
+    // Auto-detect: sign with stake key if requiredSigners includes our stake key hash
+    if (!signWithStakeKey && this.stakeSigningKey) {
+      const stakeKeyHash = (
+        await (await this.stakeSigningKey.toPublic()).toRawKey().hash()
+      ).hex();
+      const requiredSigners = tx.body().requiredSigners()?.values() ?? [];
+      for (const rs of requiredSigners) {
+        if (rs.value() === stakeKeyHash) {
+          signWithStakeKey = true;
+          break;
+        }
+      }
+    }
+
     if (signWithStakeKey) {
       if (!this.stakeSigningKey) {
         throw new Error(


### PR DESCRIPTION
## Summary

- `HotWallet.signTransaction()` now inspects `tx.body().requiredSigners()` for the wallet's stake key hash and automatically signs with the stake key when present
- This mirrors CIP-30 wallet behavior where all required keys are signed automatically
- Previously, the `signWithStakeKey` parameter was unreachable through the standard `Blaze.signTransaction()` flow (only 2 args passed), making it impossible for `HotWallet` to sign with the stake key in emulator tests

## Motivation

Sometimes it's necessary to sign a transaction with a stake credential. CIP-30 wallets handle this transparently when this credential is added to requiredSigners since they sign with all available keys. However, `HotWallet` only signed with the payment key unless `signWithStakeKey` was explicitly `true` — a parameter that `Blaze.signTransaction()` never passes.
