### PR TITLE
fix(blueprint): handle aiken v1.1.22 angle-bracket generic type names

### DIFF
--- a/.changeset/blueprint-angle-bracket-generics.md
+++ b/.changeset/blueprint-angle-bracket-generics.md
@@ -1,0 +1,5 @@
+---
+"@blaze-cardano/blueprint": patch
+---
+
+Fix blueprint generation for aiken's angle-bracket generic type names. Newer aiken encodes generics as `Tuple<<A,B>>` (built-in Tuple) and `module/MyPair<A,B>` (user generics). The generator previously understood only the older `$` encoding and emitted invalid TypeScript identifiers, so the generated blueprint no longer compiled. It now parses both bracket forms (base name and the last path segment of each type parameter, depth-aware for nesting), guards reserved-word and empty identifiers, and fails loud on a normalized-name collision instead of silently aliasing two distinct types.

--- a/packages/blaze-blueprint/src/blueprint.ts
+++ b/packages/blaze-blueprint/src/blueprint.ts
@@ -253,6 +253,90 @@ export class Generator {
     fullDefinitionName: string,
     schema?: Annotated<Schema>,
   ): string {
+    return Generator.sanitizeIdentifier(
+      this.normalizeTypeNameRaw(fullDefinitionName, schema),
+    );
+  }
+
+  // TypeScript reserved words that cannot appear as a declaration identifier.
+  private static readonly RESERVED = new Set([
+    "break", "case", "catch", "class", "const", "continue", "debugger",
+    "default", "delete", "do", "else", "enum", "export", "extends", "false",
+    "finally", "for", "function", "if", "import", "in", "instanceof", "new",
+    "null", "return", "super", "switch", "this", "throw", "true", "try",
+    "typeof", "var", "void", "while", "with", "implements", "interface",
+    "let", "package", "private", "protected", "public", "static", "yield",
+    "await",
+  ]);
+
+  // Coerce a computed name into a valid TypeScript identifier as a final guard.
+  // Replaces out-of-alphabet characters, prefixes a leading digit, suffixes a
+  // reserved word, and fails loud on an empty result (a definition name that
+  // normalizes to nothing is malformed input, not something to paper over).
+  private static sanitizeIdentifier(name: string): string {
+    let cleaned = name.replace(/[^A-Za-z0-9_$]/g, "_");
+    if (cleaned.length === 0) {
+      throw new Error(
+        `blueprint: definition name "${name}" normalizes to an empty ` +
+          `TypeScript identifier. The plutus.json definition names look malformed.`,
+      );
+    }
+    if (/^[0-9]/.test(cleaned)) cleaned = `_${cleaned}`;
+    if (Generator.RESERVED.has(cleaned)) cleaned = `${cleaned}_`;
+    return cleaned;
+  }
+
+  // Splits generic type params on top-level commas, respecting nested angle
+  // brackets. Counts every "<" as one level deeper, so the double-bracket Tuple
+  // form ("<<...>>") and the single-bracket user form ("<...>") both balance.
+  private splitTopLevelParams(inner: string): string[] {
+    const out: string[] = [];
+    let depth = 0;
+    let cur = "";
+    for (const ch of inner) {
+      if (ch === "<") depth++;
+      else if (ch === ">") depth--;
+      if (ch === "," && depth === 0) {
+        out.push(cur);
+        cur = "";
+      } else {
+        cur += ch;
+      }
+    }
+    if (cur.length > 0) out.push(cur);
+    return out;
+  }
+
+  // Normalizes aiken's angle-bracket generic encoding to an identifier. The
+  // built-in Tuple is double-bracketed ("Tuple<<A,B>>") and user generics are
+  // single-bracketed ("module/MyPair<A,B>"). Emit the base name (last path
+  // segment before the first "<") followed by each parameter's normalized name.
+  private normalizeAngleGeneric(name: string): string {
+    const firstLt = name.indexOf("<");
+    if (firstLt === -1) {
+      return name.split("/").pop()!.replace(/~/g, "_");
+    }
+    const base = name.slice(0, firstLt).split("/").pop()!.replace(/~/g, "_");
+    let open = 0;
+    while (name[firstLt + open] === "<") open++;
+    const inner = name.slice(firstLt + open, name.length - open);
+    const params = this.splitTopLevelParams(inner).map((p) =>
+      this.normalizeAngleGeneric(p.trim()),
+    );
+    return [base, ...params].join("_");
+  }
+
+  private normalizeTypeNameRaw(
+    fullDefinitionName: string,
+    schema?: Annotated<Schema>,
+  ): string {
+    // Newer aiken encodes generic instantiations with angle brackets:
+    // "Tuple<<ByteArray,Data>>" (built-in Tuple) and "module/MyPair<A,B>" (user
+    // generics). Older aiken used a "$" separator, still handled below.
+    if (fullDefinitionName.includes("<")) {
+      return this.normalizeAngleGeneric(fullDefinitionName);
+    }
+
     const parts = fullDefinitionName.split("/");
 
     // Find the part containing "$" (indicates generic type instantiation)
@@ -317,6 +401,7 @@ export class Generator {
 
   public writeModule(definitions: Record<string, Annotated<Schema>>) {
     const types = [];
+    const seen = new Map<string, string>();
     this.writeLine(`const Contracts = Type.Module({`);
     this.indent();
     for (const [name, definition] of Object.entries(definitions)) {
@@ -327,6 +412,15 @@ export class Generator {
         continue;
       }
       const normalizedName = this.normalizeTypeName(name, definition);
+      const previous = seen.get(normalizedName);
+      if (previous !== undefined && previous !== name) {
+        throw new Error(
+          `blueprint: type name collision "${normalizedName}" produced by both ` +
+            `"${previous}" and "${name}". Two distinct definitions map to the ` +
+            `same TypeScript identifier. Disambiguate the source types.`,
+        );
+      }
+      seen.set(normalizedName, name);
       types.push(normalizedName);
       this.buildLine(`${normalizedName}: `);
       this.writeTypeboxType(definition, definitions);

--- a/packages/blaze-blueprint/tests/generic/generic.test.ts
+++ b/packages/blaze-blueprint/tests/generic/generic.test.ts
@@ -9,7 +9,7 @@ import {
   AlwaysTrueWithGenericScriptNoParamsSpend,
   GenericType_OutputReference,
 } from "./plutus";
-import { Generator } from "../../src/blueprint";
+import { Generator, generateBlueprint } from "../../src/blueprint";
 
 describe("Generated code", () => {
   it("should not contain Type.Unsafe<PlutusData> to avoid TS2742 declaration emit errors", () => {
@@ -239,5 +239,102 @@ describe("Generator.normalizeTypeName", () => {
       );
       expect(result).toBe("OutputReference");
     });
+  });
+
+  describe("angle-bracket generics (aiken v1.1.22 and later)", () => {
+    it("normalizes Tuple<<ByteArray,Data>> to a valid identifier", () => {
+      expect(generator.normalizeTypeName("Tuple<<ByteArray,Data>>")).toBe(
+        "Tuple_ByteArray_Data",
+      );
+    });
+
+    it("uses the last path segment of each type parameter", () => {
+      expect(
+        generator.normalizeTypeName(
+          "Tuple<<aiken/crypto/VerificationKey,aiken/crypto/Signature>>",
+        ),
+      ).toBe("Tuple_VerificationKey_Signature");
+      expect(
+        generator.normalizeTypeName("Tuple<<types/common/AssetClass,Int>>"),
+      ).toBe("Tuple_AssetClass_Int");
+    });
+
+    it("never emits an invalid identifier for angle-bracket names", () => {
+      const out = generator.normalizeTypeName(
+        "Tuple<<types/common/ModuleHash,ByteArray>>",
+      );
+      expect(out).toBe("Tuple_ModuleHash_ByteArray");
+      expect(out).toMatch(/^[A-Za-z_$][A-Za-z0-9_$]*$/);
+    });
+
+    // Aiken single-brackets user-defined generics (only built-in Tuple is
+    // double-bracketed), so the base name must be preserved, not dropped.
+    it("normalizes single-bracket user generics and keeps the base name", () => {
+      expect(
+        generator.normalizeTypeName("genc/types/MyPair<ByteArray,Int>"),
+      ).toBe("MyPair_ByteArray_Int");
+      expect(
+        generator.normalizeTypeName(
+          "gen/MyPair<cardano/transaction/OutputReference,Int>",
+        ),
+      ).toBe("MyPair_OutputReference_Int");
+    });
+
+    it("normalizes nested single and mixed single/double generics", () => {
+      expect(
+        generator.normalizeTypeName(
+          "genc/types/MyPair<genc/types/MyPair<ByteArray,Int>,Int>",
+        ),
+      ).toBe("MyPair_MyPair_ByteArray_Int_Int");
+      expect(
+        generator.normalizeTypeName("gen/Wrap<Tuple<<ByteArray,Int>>>"),
+      ).toBe("Wrap_Tuple_ByteArray_Int");
+    });
+  });
+
+  describe("sanitize backstop", () => {
+    it("suffixes TypeScript reserved words", () => {
+      expect(generator.normalizeTypeName("mod/return")).toBe("return_");
+      expect(generator.normalizeTypeName("mod/class")).toBe("class_");
+    });
+
+    it("throws on a name that normalizes to empty", () => {
+      expect(() => generator.normalizeTypeName("mod/")).toThrow(/empty/);
+    });
+  });
+
+  describe("name-collision guard", () => {
+    it("throws when two definitions normalize to the same identifier", () => {
+      const definitions: any = {
+        "a/common/State": { dataType: "bytes" },
+        "b/other/State": { dataType: "bytes" },
+      };
+      expect(() => generator.writeModule(definitions)).toThrow(/collision/);
+    });
+  });
+});
+
+// End-to-end against a real aiken v1.1.22 plutus.json (built from a project with
+// a user generic MyPair<A,B> and a built-in tuple), so CI exercises the actual
+// angle-bracket path, not just hand-written normalizer inputs.
+describe("angle-bracket generics end to end (real aiken v1.1.22 output)", () => {
+  it("generates valid, correctly-named declarations", async () => {
+    const out = "/tmp/blaze_v1_1_22_blueprint.ts";
+    await generateBlueprint({ infile: "./plutus.v1_1_22.json", outfile: out });
+    const code = fs.readFileSync(out, "utf-8");
+    fs.rmSync(out, { force: true });
+
+    const names = [...code.matchAll(/export (?:const|type) (\S+)/g)].map(
+      (m) => m[1]!,
+    );
+    // built-in Tuple (double bracket) and user generic (single bracket, base kept)
+    expect(names).toContain("Tuple_ByteArray_Int");
+    expect(names).toContain("MyPair_ByteArray_Int");
+    expect(names).toContain("MyPair_MyPair_ByteArray_Int_Int");
+    // every declared identifier is valid TypeScript (no leftover bracket or comma)
+    expect(names.length).toBeGreaterThan(0);
+    for (const n of names) {
+      expect(n).toMatch(/^[A-Za-z_$][A-Za-z0-9_$]*$/);
+    }
   });
 });

--- a/packages/blaze-blueprint/tests/generic/plutus.v1_1_22.json
+++ b/packages/blaze-blueprint/tests/generic/plutus.v1_1_22.json
@@ -1,0 +1,208 @@
+{
+  "preamble": {
+    "title": "geoff/gencheck",
+    "description": "Aiken contracts for project 'geoff/gencheck'",
+    "version": "0.0.0",
+    "plutusVersion": "v3",
+    "compiler": {
+      "name": "Aiken",
+      "version": "v1.1.22+9117ea1"
+    },
+    "license": "Apache-2.0"
+  },
+  "validators": [
+    {
+      "title": "placeholder.placeholder.mint",
+      "redeemer": {
+        "title": "_redeemer",
+        "schema": {
+          "$ref": "#/definitions/Data"
+        }
+      },
+      "compiledCode": "58d001010029800aba2aba1aab9eaab9dab9a48888966002646465300130053754003300700398038012444b30013370e9000001c4c98dd7180518049baa0048acc004cdc3a400400713233226300b001300b300c0013009375400915980099b874801000e264c601460126ea80122b30013370e9003001c4c8cc898dd698058009805980600098049baa0048acc004cdc3a40100071326300a3009375400913233226375a60160026016601800260126ea8011007200e401c80390070c018c01c004c018004c00cdd5003452689b2b20021",
+      "hash": "f2388d136606a27c4a531d0040c3e12e07eb95cd5011793c160707dc"
+    },
+    {
+      "title": "placeholder.placeholder.spend",
+      "datum": {
+        "title": "_datum",
+        "schema": {
+          "$ref": "#/definitions/Data"
+        }
+      },
+      "redeemer": {
+        "title": "_redeemer",
+        "schema": {
+          "$ref": "#/definitions/Data"
+        }
+      },
+      "compiledCode": "58d001010029800aba2aba1aab9eaab9dab9a48888966002646465300130053754003300700398038012444b30013370e9000001c4c98dd7180518049baa0048acc004cdc3a400400713233226300b001300b300c0013009375400915980099b874801000e264c601460126ea80122b30013370e9003001c4c8cc898dd698058009805980600098049baa0048acc004cdc3a40100071326300a3009375400913233226375a60160026016601800260126ea8011007200e401c80390070c018c01c004c018004c00cdd5003452689b2b20021",
+      "hash": "f2388d136606a27c4a531d0040c3e12e07eb95cd5011793c160707dc"
+    },
+    {
+      "title": "placeholder.placeholder.withdraw",
+      "redeemer": {
+        "title": "_redeemer",
+        "schema": {
+          "$ref": "#/definitions/Data"
+        }
+      },
+      "compiledCode": "58d001010029800aba2aba1aab9eaab9dab9a48888966002646465300130053754003300700398038012444b30013370e9000001c4c98dd7180518049baa0048acc004cdc3a400400713233226300b001300b300c0013009375400915980099b874801000e264c601460126ea80122b30013370e9003001c4c8cc898dd698058009805980600098049baa0048acc004cdc3a40100071326300a3009375400913233226375a60160026016601800260126ea8011007200e401c80390070c018c01c004c018004c00cdd5003452689b2b20021",
+      "hash": "f2388d136606a27c4a531d0040c3e12e07eb95cd5011793c160707dc"
+    },
+    {
+      "title": "placeholder.placeholder.publish",
+      "redeemer": {
+        "title": "_redeemer",
+        "schema": {
+          "$ref": "#/definitions/Data"
+        }
+      },
+      "compiledCode": "58d001010029800aba2aba1aab9eaab9dab9a48888966002646465300130053754003300700398038012444b30013370e9000001c4c98dd7180518049baa0048acc004cdc3a400400713233226300b001300b300c0013009375400915980099b874801000e264c601460126ea80122b30013370e9003001c4c8cc898dd698058009805980600098049baa0048acc004cdc3a40100071326300a3009375400913233226375a60160026016601800260126ea8011007200e401c80390070c018c01c004c018004c00cdd5003452689b2b20021",
+      "hash": "f2388d136606a27c4a531d0040c3e12e07eb95cd5011793c160707dc"
+    },
+    {
+      "title": "placeholder.placeholder.vote",
+      "redeemer": {
+        "title": "_redeemer",
+        "schema": {
+          "$ref": "#/definitions/Data"
+        }
+      },
+      "compiledCode": "58d001010029800aba2aba1aab9eaab9dab9a48888966002646465300130053754003300700398038012444b30013370e9000001c4c98dd7180518049baa0048acc004cdc3a400400713233226300b001300b300c0013009375400915980099b874801000e264c601460126ea80122b30013370e9003001c4c8cc898dd698058009805980600098049baa0048acc004cdc3a40100071326300a3009375400913233226375a60160026016601800260126ea8011007200e401c80390070c018c01c004c018004c00cdd5003452689b2b20021",
+      "hash": "f2388d136606a27c4a531d0040c3e12e07eb95cd5011793c160707dc"
+    },
+    {
+      "title": "placeholder.placeholder.propose",
+      "redeemer": {
+        "title": "_redeemer",
+        "schema": {
+          "$ref": "#/definitions/Data"
+        }
+      },
+      "compiledCode": "58d001010029800aba2aba1aab9eaab9dab9a48888966002646465300130053754003300700398038012444b30013370e9000001c4c98dd7180518049baa0048acc004cdc3a400400713233226300b001300b300c0013009375400915980099b874801000e264c601460126ea80122b30013370e9003001c4c8cc898dd698058009805980600098049baa0048acc004cdc3a40100071326300a3009375400913233226375a60160026016601800260126ea8011007200e401c80390070c018c01c004c018004c00cdd5003452689b2b20021",
+      "hash": "f2388d136606a27c4a531d0040c3e12e07eb95cd5011793c160707dc"
+    },
+    {
+      "title": "placeholder.placeholder.else",
+      "redeemer": {
+        "schema": {}
+      },
+      "compiledCode": "58d001010029800aba2aba1aab9eaab9dab9a48888966002646465300130053754003300700398038012444b30013370e9000001c4c98dd7180518049baa0048acc004cdc3a400400713233226300b001300b300c0013009375400915980099b874801000e264c601460126ea80122b30013370e9003001c4c8cc898dd698058009805980600098049baa0048acc004cdc3a40100071326300a3009375400913233226375a60160026016601800260126ea8011007200e401c80390070c018c01c004c018004c00cdd5003452689b2b20021",
+      "hash": "f2388d136606a27c4a531d0040c3e12e07eb95cd5011793c160707dc"
+    },
+    {
+      "title": "v.demo.spend",
+      "datum": {
+        "title": "datum",
+        "schema": {
+          "$ref": "#/definitions/v~1Datum"
+        }
+      },
+      "redeemer": {
+        "title": "_r",
+        "schema": {
+          "$ref": "#/definitions/Data"
+        }
+      },
+      "compiledCode": "585c01010029800aba2aba1aab9eaab9dab9a4888896600264653001300600198031803800cc0180092225980099b8748008c01cdd500144c8cc892898050009805180580098041baa0028b200c180300098019baa0068a4d13656400401",
+      "hash": "d27ccc13fab5b782984a3d1f99353197ca1a81be069941ffc003ee75"
+    },
+    {
+      "title": "v.demo.else",
+      "redeemer": {
+        "schema": {}
+      },
+      "compiledCode": "585c01010029800aba2aba1aab9eaab9dab9a4888896600264653001300600198031803800cc0180092225980099b8748008c01cdd500144c8cc892898050009805180580098041baa0028b200c180300098019baa0068a4d13656400401",
+      "hash": "d27ccc13fab5b782984a3d1f99353197ca1a81be069941ffc003ee75"
+    }
+  ],
+  "definitions": {
+    "ByteArray": {
+      "dataType": "bytes"
+    },
+    "Data": {
+      "title": "Data",
+      "description": "Any Plutus data."
+    },
+    "Int": {
+      "dataType": "integer"
+    },
+    "Tuple<<ByteArray,Int>>": {
+      "title": "Tuple",
+      "dataType": "list",
+      "items": [
+        {
+          "$ref": "#/definitions/ByteArray"
+        },
+        {
+          "$ref": "#/definitions/Int"
+        }
+      ]
+    },
+    "genc/types/MyPair<ByteArray,Int>": {
+      "title": "MyPair",
+      "anyOf": [
+        {
+          "title": "MyPair",
+          "dataType": "constructor",
+          "index": 0,
+          "fields": [
+            {
+              "title": "fst",
+              "$ref": "#/definitions/ByteArray"
+            },
+            {
+              "title": "snd",
+              "$ref": "#/definitions/Int"
+            }
+          ]
+        }
+      ]
+    },
+    "genc/types/MyPair<genc/types/MyPair<ByteArray,Int>,Int>": {
+      "title": "MyPair",
+      "anyOf": [
+        {
+          "title": "MyPair",
+          "dataType": "constructor",
+          "index": 0,
+          "fields": [
+            {
+              "title": "fst",
+              "$ref": "#/definitions/genc~1types~1MyPair<ByteArray,Int>"
+            },
+            {
+              "title": "snd",
+              "$ref": "#/definitions/Int"
+            }
+          ]
+        }
+      ]
+    },
+    "v/Datum": {
+      "title": "Datum",
+      "anyOf": [
+        {
+          "title": "Datum",
+          "dataType": "constructor",
+          "index": 0,
+          "fields": [
+            {
+              "title": "pair",
+              "$ref": "#/definitions/genc~1types~1MyPair<ByteArray,Int>"
+            },
+            {
+              "title": "nested",
+              "$ref": "#/definitions/genc~1types~1MyPair<genc~1types~1MyPair<ByteArray,Int>,Int>"
+            },
+            {
+              "title": "tup",
+              "$ref": "#/definitions/Tuple<<ByteArray,Int>>"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## What?

The type-name normalizer only recognized aiken's older `$` generic encoding (`Tuple$ByteArray_Data`). Aiken v1.1.22 switched to angle brackets: the built-in `Tuple` as `Tuple<<ByteArray,Data>>` and user-defined generics as `module/MyPair<A,B>` (single bracket). The normalizer copied the raw name through as a TypeScript identifier, so the generated `blueprint.ts` no longer parsed. This parses both the single- and double-bracket forms (base name and last path-segment of each param, depth-aware for nesting), keeps the `$` path for older aiken, adds a final identifier-sanitize guard (out-of-alphabet chars, leading digit, reserved words, and a throw on an empty result), and fails loud on a normalized-name collision instead of silently aliasing two types.

## Why?

After aiken v1.1.22 any project with generic types generates a `blueprint.ts` that does not compile, e.g. `export const Tuple<<ByteArray,Data>> = ...`. Root cause: the normalizer hardcoded one aiken name-encoding. Only the built-in `Tuple` is double-bracketed; user generics are single-bracketed, so a Tuple-only fix would still mangle every user generic (`MyPair<...>` losing its base name and colliding), which is why this handles both forms.

## Testing done

The full suite passes (`test:simple` 6/6, `test:complex` 7/7, `test:generic` 27/27). New unit tests cover single, double, nested, and path-qualified generics, reserved words, empty names, and the collision guard. A committed aiken v1.1.22 fixture (built from a project with a user generic and a built-in tuple) drives an end-to-end test, so CI exercises the real angle-bracket path: `MyPair<ByteArray,Int>` normalizes to `MyPair_ByteArray_Int`, `Tuple<<ByteArray,Int>>` to `Tuple_ByteArray_Int`, and every declared identifier is valid. Legacy `$`-encoded fixtures still generate byte-identically to before the change, so there is no regression for older-aiken projects.

## Notes

The collision guard also applies to non-generic names (for example two same-named types in different modules), turning what was previously a duplicate-declaration crash at import time into a clear build-time error. `dist/` is gitignored, so consumers rebuild the package to pick up the fix. The `isStandardType` predicate matches standard containers by bare prefix (`startsWith("List")` and similar), so a user type whose key starts with a capitalized standard-container name is still mis-classified. That is a pre-existing issue independent of this change and left for a separate fix.
