### PR TITLE
Fix native script resolution

### DIFF
--- a/packages/blaze-tx/src/TxBuilder.ts
+++ b/packages/blaze-tx/src/TxBuilder.ts
@@ -1351,11 +1351,10 @@ export class TxBuilder {
       }
 
       if (key.type == CredentialType.ScriptHash) {
-        const nativeScript = output.scriptRef()?.asNative() !== undefined;
-        if (nativeScript) {
-          this.requiredNativeScripts.add(key.hash);
-        } else {
-          this.requiredPlutusScripts.add(key.hash);
+        if (!Array.from(this.scriptScope).some(script => script.hash() === key.hash)) {
+          throw new Error(
+            `updateRequiredWitnesses: could not resolve script hash ${key.hash} for input ${input.transactionId()}#${input.index()}`,
+          );
         }
       } else {
         this.requiredWitnesses.add(HashAsPubKeyHex(key.hash));

--- a/packages/blaze-tx/src/TxBuilder.ts
+++ b/packages/blaze-tx/src/TxBuilder.ts
@@ -1351,7 +1351,11 @@ export class TxBuilder {
       }
 
       if (key.type == CredentialType.ScriptHash) {
-        if (!Array.from(this.scriptScope).some(script => script.hash() === key.hash)) {
+        if (
+          !Array.from(this.scriptScope).some(
+            (script) => script.hash() === key.hash,
+          )
+        ) {
           throw new Error(
             `updateRequiredWitnesses: could not resolve script hash ${key.hash} for input ${input.transactionId()}#${input.index()}`,
           );


### PR DESCRIPTION
Currently native scripts are assumed Plutus scripts during resolution and erroneously added to the witness set twice unless their inputs happen to carry a native script as `scriptRef`.  This change has `TxBuilder` assert that any spending script has already been provided  and exists in `scriptScope`.